### PR TITLE
Refine retrospective boredom logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,7 @@ The core benefit is space for reflection, creativity, emotional processing, and 
 ## Current Prototype Context
 
 This project started as a learning project by a beginner developer. Expect rough edges, unfinished UI, and old dependencies. Preserve the playful concept while improving quality incrementally.
+
+## Local Preview
+
+- See [docs/local-preview.md](docs/local-preview.md) for running a phone-ready preview with Portless and Tailscale, including the Vite `allowedHosts` gotcha.

--- a/docs/local-preview.md
+++ b/docs/local-preview.md
@@ -1,0 +1,54 @@
+# Local Preview
+
+Use `portless` when the user needs to inspect a local app preview from another device.
+
+## Start A Phone-Ready Preview
+
+Run from the repo root:
+
+```bash
+portless bored-calendar --tailscale vp run dev
+```
+
+This starts Astro through `vp run dev`, proxies it through Portless, and prints a Tailscale URL. Use the URL printed by your local Portless process; do not commit or document private tailnet hostnames.
+
+The app route is:
+
+```text
+<tailscale-url>/app/
+```
+
+The exact hostname and port may change. Confirm active routes with:
+
+```bash
+portless list
+```
+
+## Vite Allowed Host Gotcha
+
+If the phone shows this error:
+
+```text
+Blocked request. This host ("<tailscale-host>") is not allowed.
+```
+
+For local preview only, add the printed Tailscale hostname to the Vite dev-server `allowedHosts` config, restart the Portless preview, and do not commit the private hostname.
+
+Example shape:
+
+```js
+server: {
+  allowedHosts: ["<tailscale-host>"],
+}
+```
+
+## Browser QA From The VM
+
+The Tailscale hostname may not resolve from inside the VM. If agent-browser cannot open the Tailscale URL, use the direct local app port printed by Portless instead:
+
+```bash
+agent-browser open http://localhost:<port>/app/
+agent-browser snapshot -i
+```
+
+This still tests the same running app; the phone should use the Tailscale URL.

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -38,12 +38,23 @@ const CircularSlider =
 
 const queryClient = new QueryClient();
 
+type LogEntry = {
+  id: number;
+  date: string;
+  time: number;
+  reflection?: string;
+};
+
 const App: React.FC<{}> = () => {
   const [value, onChange] = React.useState(new Date());
   const dayStart = new Date(value);
   dayStart.setHours(0, 0, 0, 0);
   const dayStartTime = dayStart.getTime();
-  const date = `${value.getDate()}${value.getMonth() + 1}${value.getFullYear()}`;
+  const date = value.toLocaleDateString(undefined, {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
 
   const {
     isLoading: loadingDate,
@@ -55,104 +66,177 @@ const App: React.FC<{}> = () => {
     queryFn: async () => {
       const indexedDb = new IndexedDb("Calendar");
       await indexedDb.createObjectStore(["Logs"]);
-      const upload = await indexedDb.getValue("Logs", dayStartTime);
-      await indexedDb.putValue("Logs", {
+      const upload = (await indexedDb.getValue("Logs", dayStartTime)) as LogEntry | undefined;
+      const localData: LogEntry = {
         id: dayStartTime,
         date: date,
         time: upload === undefined ? 0 : upload.time,
-      });
-      const localData = await indexedDb.getValue("Logs", dayStartTime);
-      return [localData.time];
+        reflection: upload?.reflection ?? "",
+      };
+      await indexedDb.putValue("Logs", localData);
+      return localData;
+    },
+  });
+
+  const { error: errorAll, data: dataAll } = useQuery({
+    queryKey: ["logs"],
+    queryFn: async () => {
+      const indexedDb = new IndexedDb("Calendar");
+      await indexedDb.createObjectStore(["Logs"]);
+      const allDB = (await indexedDb.getAllValue("Logs")) as LogEntry[];
+      return allDB;
     },
   });
 
   if (errorDate) console.log(errorDate);
+  if (errorAll) console.log(errorAll);
 
-  const useTime = () => {
+  const loggedDays = new Map(dataAll?.map((entry) => [entry.id, entry]) ?? []);
+
+  const useLogEntry = () => {
     return useMutation({
-      mutationFn: async (addTime: number) => {
+      mutationFn: async ({ minutes, reflection }: { minutes: number; reflection: string }) => {
         const indexedDb = new IndexedDb("Calendar");
         await indexedDb.createObjectStore(["Logs"]);
-        const minuts = dataDate || 0;
+        const trimmedReflection = reflection.trim();
+
+        if (minutes === 0 && trimmedReflection === "") {
+          await indexedDb.deleteValue("Logs", dayStartTime);
+          await refetch();
+          await queryClient.invalidateQueries({ queryKey: ["logs"] });
+          return;
+        }
+
         await indexedDb
           .putValue("Logs", {
             id: dayStartTime,
             date: date,
-            time: +minuts + addTime,
+            time: minutes,
+            reflection: trimmedReflection,
           })
-          .then(refetch);
+          .then(async () => {
+            await refetch();
+            await queryClient.invalidateQueries({ queryKey: ["logs"] });
+          });
         return;
       },
     });
   };
 
-  const addTime = useTime();
+  const logEntry = useLogEntry();
 
-  const ButtonTimer = ({ onClick }: { onClick: () => void }) => {
-    const [minuts, setMinuts] = React.useState(0);
+  const LogMoment = ({
+    initialMinutes,
+    initialReflection,
+  }: {
+    initialMinutes: number;
+    initialReflection: string;
+  }) => {
+    const [minutes, setMinutes] = React.useState(initialMinutes);
+    const [reflection, setReflection] = React.useState(initialReflection);
     const [click, setClick] = React.useState(true);
+    const savedMinutes = initialMinutes;
+    const savedReflection = initialReflection.trim();
+    const currentReflection = reflection.trim();
+    const hasSavedDay = savedMinutes > 0 || savedReflection !== "";
+    const hasChanges = minutes !== savedMinutes || currentReflection !== savedReflection;
+    const canSave = hasChanges;
+    const buttonText = hasSavedDay ? "Update day" : "Save day";
 
     return (
-      <>
-        <CircularSlider
-          width={165}
-          min={0}
-          max={15}
-          valueFontSize="2rem"
-          label="You Bored?"
-          labelColor="#FFFFFF"
-          labelBottom={true}
-          labelFontSize="1rem"
-          knobColor="#1C1C1E"
-          progressColorFrom="#B1D0E6"
-          progressColorTo="#9CA3AF"
-          progressSize={16}
-          trackSize={16}
-          trackColor="#F9FAFB"
-          dataIndex={0}
-          onChange={(value: any) => {
-            setMinuts(value);
-          }}
-        />
-        <div
-          className={
-            click
-              ? "bg-bluish-500 absolute z-50 cursor-pointer rounded-full h-28 w-28"
-              : "bg-grayish-900 absolute z-50 cursor-pointer rounded-full h-28 w-28"
-          }
-        >
-          <button
-            type="button"
-            className="flex flex-col justify-center items-center h-28 w-28 cursor-pointer border-0 bg-transparent p-0"
-            onMouseDown={() => setClick(false)}
-            onMouseUp={() => setClick(true)}
-            onMouseLeave={() => setClick(true)}
-            onClick={(e) => {
-              e.stopPropagation();
-              addTime.mutateAsync(minuts).catch((err) => console.log(err));
-              onClick();
-            }}
-          >
-            <div className="text-white">{minuts}</div>
-            <div className="text-white">You Bored?</div>
-          </button>
+      <div className="flex flex-col gap-3 rounded-2xl bg-bluish-100 px-4 py-4">
+        <div>
+          <div className="font-bold">Remember this day</div>
+          <div className="text-sm text-grayish-800">
+            Each date keeps one total and one optional note. Set this day to what you remember.
+          </div>
         </div>
-      </>
+        <div className="relative flex items-center justify-center py-2">
+          <CircularSlider
+            width={165}
+            min={0}
+            max={15}
+            valueFontSize="2rem"
+            label="minutes"
+            labelColor="#FFFFFF"
+            labelBottom={true}
+            labelFontSize="1rem"
+            knobColor="#1C1C1E"
+            progressColorFrom="#B1D0E6"
+            progressColorTo="#9CA3AF"
+            progressSize={16}
+            trackSize={16}
+            trackColor="#F9FAFB"
+            dataIndex={minutes}
+            onChange={(value) => {
+              setMinutes(value);
+            }}
+          />
+          <div
+            className={
+              canSave && click
+                ? "bg-bluish-500 absolute z-50 cursor-pointer rounded-full h-28 w-28"
+                : "bg-grayish-600 absolute z-50 cursor-pointer rounded-full h-28 w-28"
+            }
+          >
+            <button
+              type="button"
+              className="flex flex-col justify-center items-center h-28 w-28 cursor-pointer border-0 bg-transparent p-0 disabled:cursor-default"
+              disabled={!canSave}
+              onMouseDown={() => canSave && setClick(false)}
+              onMouseUp={() => setClick(true)}
+              onMouseLeave={() => setClick(true)}
+              onClick={(e) => {
+                e.stopPropagation();
+                if (!canSave) {
+                  return;
+                }
+                logEntry.mutateAsync({ minutes, reflection }).catch((err) => console.log(err));
+              }}
+            >
+              <div className="text-white">{minutes}</div>
+              <div className="text-center text-sm text-white">{buttonText}</div>
+            </button>
+          </div>
+        </div>
+        <div className="text-center text-sm text-grayish-800">
+          {canSave ? "You have unsaved changes for this day." : "No changes to save."}
+        </div>
+        <label htmlFor="bored-reflection" className="flex flex-col gap-2 text-sm text-grayish-900">
+          Note for this day <span className="text-grayish-800">Optional</span>
+          <textarea
+            id="bored-reflection"
+            aria-label="Note for this day. Optional"
+            className="min-h-20 rounded-xl border border-grayish-700 bg-white p-3 text-grayish-900"
+            value={reflection}
+            onChange={(event) => setReflection(event.target.value)}
+            placeholder="What surfaced when you were bored?"
+          />
+        </label>
+        <div className="text-xs text-grayish-800">
+          Set minutes to 0 and clear the note to remove this day from the calendar.
+        </div>
+      </div>
     );
   };
 
-  const Today = () => {
-    const timeIsToday = dataDate || 0;
+  const SelectedDay = () => {
+    const selectedMinutes = dataDate?.time ?? 0;
     return (
       <div className="px-4 py-4 rounded-2xl bg-grayish-500">
-        <div className="font-bold">Today</div>
-        <div>{timeIsToday} minutes of boredom so far.</div>
+        <div className="font-bold">{date}</div>
+        <div>{selectedMinutes} minutes of boredom remembered.</div>
+        {dataDate?.reflection && (
+          <div className="mt-2 rounded-xl bg-white p-3 text-sm text-grayish-900">
+            {dataDate.reflection}
+          </div>
+        )}
         <Bullet
           data={[
             {
               id: "",
               ranges: [0, 60],
-              measures: [+timeIsToday],
+              measures: [selectedMinutes],
               markers: [5, 20],
             },
           ]}
@@ -172,22 +256,10 @@ const App: React.FC<{}> = () => {
   };
 
   const Statistic = () => {
-    const { error: errorAll, data: dataAll } = useQuery({
-      queryKey: [`logs`],
-      queryFn: async () => {
-        const indexedDb = new IndexedDb("Calendar");
-        await indexedDb.createObjectStore(["Logs"]);
-        const allDB = await indexedDb.getAllValue("Logs");
-        return allDB;
-      },
-    });
-
-    if (errorAll) console.log(errorAll);
-
     const statistics =
       dataAll
-        ?.reverse()
-        .map((x: any) => ({
+        ?.toReversed()
+        .map((x: LogEntry) => ({
           id: `${x.date}`,
           ranges: [1, 5, 20, 40, 60],
           measures: [x.time],
@@ -196,8 +268,8 @@ const App: React.FC<{}> = () => {
         .slice(0, 7) || [];
 
     return (
-      <div className="px-4 py-4 rounded-2xl bg-grayish-500">
-        <div className="font-bold">Patterns</div>
+      <details className="rounded-2xl bg-grayish-500 px-4 py-4">
+        <summary className="cursor-pointer font-bold">Patterns</summary>
         <div className="text-sm text-grayish-800">A quiet look back — no scores, no streaks.</div>
         <Bullet
           data={statistics}
@@ -216,7 +288,7 @@ const App: React.FC<{}> = () => {
           height={300}
           width={300}
         />
-      </div>
+      </details>
     );
   };
 
@@ -225,20 +297,38 @@ const App: React.FC<{}> = () => {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="font-bold">Your bored moments</h1>
-          <div className="text-sm text-grayish-800">Pick a day and sit with it.</div>
+          <div className="text-sm text-grayish-800">
+            Pick a date, then save what you remember from that day.
+          </div>
         </div>
         <img src="/celendar.svg" alt="" />
       </div>
       {!loadingDate && (
-        <Calendar onChange={(v) => v instanceof Date && onChange(v)} value={value} />
+        <Calendar
+          onChange={(v) => v instanceof Date && onChange(v)}
+          tileContent={({ date: tileDate, view }) => {
+            const tileDayStart = new Date(tileDate);
+            tileDayStart.setHours(0, 0, 0, 0);
+            const log = loggedDays.get(tileDayStart.getTime());
+
+            if (view !== "month" || log === undefined || log.time === 0) {
+              return null;
+            }
+
+            return <span className="mx-auto mt-1 block h-1.5 w-1.5 rounded-full bg-bluish-500" />;
+          }}
+          value={value}
+        />
       )}
-      {!loadingDate && dataDate && <Statistic />}
-      <div>
-        <Today />
-      </div>
+      <SelectedDay />
       <div className="flex items-center justify-center">
-        <ButtonTimer onClick={() => queryClient.invalidateQueries({ queryKey: ["Logs"] })} />
+        <LogMoment
+          key={dayStartTime}
+          initialMinutes={dataDate?.time ?? 0}
+          initialReflection={dataDate?.reflection ?? ""}
+        />
       </div>
+      {!loadingDate && dataDate && <Statistic />}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Reframe /app as a retrospective daily boredom ledger
- Store one editable daily summary: remembered minutes plus optional note
- Show saved days on the calendar and make unchanged save states inactive
- Add Portless/Tailscale local-preview docs and allow the Tailscale dev host

## Verification
- vp check
- vp run test
- vp run knip
- vp run build