### PR TITLE
Validate IndexedDB log entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tanstack/react-query": "5.100.14",
     "@types/react": "19.2.15",
     "@types/react-dom": "19.2.3",
+    "arktype": "2.2.0",
     "astro": "6.4.2",
     "idb": "8.0.3",
     "react": "19.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.15)
+      arktype:
+        specifier: 2.2.0
+        version: 2.2.0
       astro:
         specifier: 6.4.2
         version: 6.4.2(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(yaml@2.9.0)
@@ -68,6 +71,12 @@ importers:
         version: 2.9.0
 
 packages:
+
+  '@ark/schema@0.56.0':
+    resolution: {integrity: sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA==}
+
+  '@ark/util@0.56.0':
+    resolution: {integrity: sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA==}
 
   '@astrojs/check@0.9.9':
     resolution: {integrity: sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg==}
@@ -1764,6 +1773,12 @@ packages:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
 
+  arkregex@0.0.5:
+    resolution: {integrity: sha512-ncYjBdLlh5/QnVsAA8De16Tc9EqmYM7y/WU9j+236KcyYNUXogpz3sC4ATIZYzzLxwI+0sEOaQLEmLmRleaEXw==}
+
+  arktype@2.2.0:
+    resolution: {integrity: sha512-t54MZ7ti5BhOEvzEkgKnWvqj+UbDfWig+DHr5I34xatymPusKLS0lQpNJd8M6DzmIto2QGszHfNKoFIT8tMCZQ==}
+
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
 
@@ -3188,6 +3203,12 @@ packages:
 
 snapshots:
 
+  '@ark/schema@0.56.0':
+    dependencies:
+      '@ark/util': 0.56.0
+
+  '@ark/util@0.56.0': {}
+
   '@astrojs/check@0.9.9(prettier@3.8.3)(typescript@5.9.3)':
     dependencies:
       '@astrojs/language-server': 2.16.10(prettier@3.8.3)(typescript@5.9.3)
@@ -4552,6 +4573,16 @@ snapshots:
   argparse@2.0.1: {}
 
   aria-query@5.3.2: {}
+
+  arkregex@0.0.5:
+    dependencies:
+      '@ark/util': 0.56.0
+
+  arktype@2.2.0:
+    dependencies:
+      '@ark/schema': 0.56.0
+      '@ark/util': 0.56.0
+      arkregex: 0.0.5
 
   array-iterate@2.0.1: {}
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3,6 +3,7 @@ import Calendar from "react-calendar";
 import * as CircularSliderModule from "@fseehawer/react-circular-slider";
 import { Bullet } from "@nivo/bullet";
 import { QueryClient, QueryClientProvider, useMutation, useQuery } from "@tanstack/react-query";
+import { validateStoredLogEntries, validateStoredLogEntry, type LogEntry } from "./logEntry";
 
 // Assets in public/ are referenced by URL, not imported (Astro 3+ astro:assets).
 import "react-calendar/dist/Calendar.css";
@@ -38,13 +39,6 @@ const CircularSlider =
 
 const queryClient = new QueryClient();
 
-type LogEntry = {
-  id: number;
-  date: string;
-  time: number;
-  reflection?: string;
-};
-
 const App: React.FC<{}> = () => {
   const [value, onChange] = React.useState(new Date());
   const dayStart = new Date(value);
@@ -66,7 +60,10 @@ const App: React.FC<{}> = () => {
     queryFn: async () => {
       const indexedDb = new IndexedDb("Calendar");
       await indexedDb.createObjectStore(["Logs"]);
-      const upload = (await indexedDb.getValue("Logs", dayStartTime)) as LogEntry | undefined;
+      const upload = validateStoredLogEntry(
+        await indexedDb.getValue("Logs", dayStartTime),
+        "Logs.getValue",
+      );
       const localData: LogEntry = {
         id: dayStartTime,
         date: date,
@@ -83,8 +80,7 @@ const App: React.FC<{}> = () => {
     queryFn: async () => {
       const indexedDb = new IndexedDb("Calendar");
       await indexedDb.createObjectStore(["Logs"]);
-      const allDB = (await indexedDb.getAllValue("Logs")) as LogEntry[];
-      return allDB;
+      return validateStoredLogEntries(await indexedDb.getAllValue("Logs"), "Logs.getAllValue");
     },
   });
 

--- a/src/components/logEntry.ts
+++ b/src/components/logEntry.ts
@@ -1,0 +1,37 @@
+import { type as arktype } from "arktype";
+
+export const LogEntry = arktype({
+  id: "number",
+  date: "string",
+  time: "number",
+  "reflection?": "string",
+  "+": "reject",
+});
+
+export type LogEntry = typeof LogEntry.infer;
+
+function validateLogEntry(data: unknown, context: string): LogEntry {
+  try {
+    return LogEntry.assert(data);
+  } catch (error) {
+    throw new Error(
+      `Log entry failed validation (${context}): ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+export function validateStoredLogEntry(data: unknown, context: string): LogEntry | undefined {
+  if (data === undefined) {
+    return undefined;
+  }
+
+  return validateLogEntry(data, context);
+}
+
+export function validateStoredLogEntries(data: unknown, context: string): LogEntry[] {
+  if (!Array.isArray(data)) {
+    throw new Error(`Log entry list failed validation (${context}): expected an array`);
+  }
+
+  return data.map((entry, index) => validateLogEntry(entry, `${context}[${index}]`));
+}


### PR DESCRIPTION
## Summary
- add ArkType runtime validation for stored boredom log entries
- validate IndexedDB single-row and list reads before app code trusts them
- replace unsafe LogEntry casts with schema-derived types

## Checks
- vp check
- vp run test
- vp run knip
- vp run build