### PR TITLE
Allow Portless Tailscale preview host

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,10 +6,27 @@ import react from "@astrojs/react";
 // Tailwind 4 is wired in through its Vite plugin, not an Astro integration.
 import tailwindcss from "@tailwindcss/vite";
 
+function getHostname(url) {
+  if (!url) {
+    return undefined;
+  }
+
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return undefined;
+  }
+}
+
+const portlessTailscaleHost = getHostname(process.env.PORTLESS_TAILSCALE_URL);
+
 // https://astro.build/config
 export default defineConfig({
   integrations: [react()],
   vite: {
     plugins: [tailwindcss()],
+    server: {
+      allowedHosts: portlessTailscaleHost ? [portlessTailscaleHost] : [],
+    },
   },
 });


### PR DESCRIPTION
## Summary
- read the Portless Tailscale preview URL from PORTLESS_TAILSCALE_URL
- allow that hostname in Vite dev server config without hard-coding a private tailnet host
- keeps production build behavior unchanged when the env var is absent

## Checks
- vp check
- vp run test
- vp run build

## Manual verification
- restarted Portless preview
- verified Vite returns 200 for Host: lima-default.tail052173.ts.net via the local dev server