### PR TITLE
Add JSON import/export and persistent local storage (#21)

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -23,4 +23,5 @@ jobs:
           git diff --exit-code .github/workflows/
       - run: vp check
       - run: vp run test
+      - run: vp test run
       - run: vp run build

--- a/.github/workflows/ci.main.ts
+++ b/.github/workflows/ci.main.ts
@@ -26,6 +26,7 @@ const wf = workflow({
         },
         { run: "vp check" },
         { run: "vp run test" },
+        { run: "vp test run" },
         { run: "vp run build" },
       ],
     },

--- a/docs/data-portability.md
+++ b/docs/data-portability.md
@@ -1,0 +1,100 @@
+# Data portability (JSON import/export)
+
+Bored Calendar stores your days locally in the browser (IndexedDB). To make
+backup, restore, and moving between devices possible **without an account or
+cloud sync**, the app can export all local data to a JSON file and import it
+back.
+
+This document describes the on-disk format so future versions can migrate old
+files safely.
+
+## Where it lives in the UI
+
+On the `/app` screen, open the **Backup & restore** section:
+
+- **Export JSON** downloads a file named `bored-calendar-YYYY-MM-DD.json`.
+- **Import JSON** reads a file and merges its days into local storage.
+- **Persistent storage** shows whether the browser has agreed to keep your data
+  (and offers a button to request it where supported).
+
+## File format
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "exportedAt": "2026-06-06T00:00:00.000Z", // ISO-8601, informational
+  "days": [
+    {
+      "id": 1780704000000, // local midnight of the day, in epoch ms (the storage key)
+      "date": "Jun 6, 2026", // human-readable label as rendered when saved
+      "time": 20, // minutes of boredom remembered (integer, 0–240)
+      "reflection": "", // optional free-text note
+    },
+  ],
+}
+```
+
+The shape of each day matches the `LogEntry` type used by IndexedDB
+(`src/components/logEntry.ts`), so an export is a faithful snapshot of stored
+data.
+
+A canonical example lives at
+[`src/lib/fixtures/example-export.json`](../src/lib/fixtures/example-export.json)
+and is kept valid by a test, so it is safe to load into the app for dev/QA.
+
+### Field notes
+
+- `id` is the day's local-midnight timestamp in epoch milliseconds. It is the
+  IndexedDB key, so it determines which day an entry overwrites on import.
+- `date` is a display label produced by `toLocaleDateString`. It is not parsed
+  on import; `id` is the source of truth.
+- `reflection` is optional and may be omitted or empty.
+- Unknown/extra keys are **rejected** (strict validation), both at the top level
+  and inside each day.
+
+## Import behavior: merge (upsert), never destructive
+
+Import **merges** by `id`:
+
+- Days in the file are added.
+- Days already present with the same `id` are **overwritten** (imported wins).
+- Days that exist locally but are absent from the file are **left untouched**.
+
+This means importing a partial or older export can never wipe local history.
+There is intentionally no "replace all" mode in this version.
+
+## Validation and safety
+
+Import validates the whole file **before writing anything**:
+
+1. The file must be valid JSON.
+2. `schemaVersion` must equal the version this app understands (currently `1`).
+   A recognizably newer file produces a clear version message.
+3. The envelope and every day must match the expected shape (via
+   [arktype](https://arktype.io/)).
+
+If any check fails, the user sees a gentle message and **no data is changed**.
+
+## Versioning and future migrations
+
+`schemaVersion` is a single integer, bumped only on non-additive changes.
+`SCHEMA_VERSION` is defined in `src/lib/dataPortability.ts`. To introduce a v2:
+
+1. Bump `SCHEMA_VERSION` to `2` and update the `BoredExport` schema.
+2. In `parseExport`, branch on the detected version and upgrade v1 payloads to
+   the v2 shape before validation (instead of rejecting them).
+3. Add a fixture and tests for the new version.
+
+Because the version is detected before strict validation, old files can be
+recognized and migrated rather than rejected.
+
+## Relationship to sync (Jazz spike)
+
+JSON import/export is the local-only foundation. A separate spike (issue #22)
+explores Jazz for optional multi-device sync, including how identity/secret
+material could extend this export format for "restore this device" vs "add a new
+device" flows. See [`docs/jazz-spike.md`](./jazz-spike.md) once that lands.
+
+```
+
+```

--- a/knip.json
+++ b/knip.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
-  "entry": [".github/workflows/*.main.ts", "vite.config.ts"]
+  "entry": [".github/workflows/*.main.ts", "src/**/*.test.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -31,9 +31,11 @@
   "devDependencies": {
     "@astrojs/check": "0.9.9",
     "@jlarky/gha-ts": "npm:@jsr/jlarky__gha-ts@^0.2.2",
+    "@types/node": "24.10.1",
     "knip": "6.14.2",
     "typescript": "5.9.3",
     "vite-plus": "0.1.23",
+    "vitest": "4.1.5",
     "yaml": "^2.9.0"
   },
   "packageManager": "pnpm@10.33.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@astrojs/react':
         specifier: 5.0.6
-        version: 5.0.6(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(yaml@2.9.0)
+        version: 5.0.6(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(yaml@2.9.0)
       '@fseehawer/react-circular-slider':
         specifier: 3.3.3
         version: 3.3.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -19,7 +19,7 @@ importers:
         version: 0.99.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tailwindcss/vite':
         specifier: 4.3.0
-        version: 4.3.0(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+        version: 4.3.0(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
       '@tanstack/react-query':
         specifier: 5.100.14
         version: 5.100.14(react@19.2.6)
@@ -34,7 +34,7 @@ importers:
         version: 2.2.0
       astro:
         specifier: 6.4.2
-        version: 6.4.2(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(yaml@2.9.0)
+        version: 6.4.2(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(yaml@2.9.0)
       idb:
         specifier: 8.0.3
         version: 8.0.3
@@ -57,6 +57,9 @@ importers:
       '@jlarky/gha-ts':
         specifier: npm:@jsr/jlarky__gha-ts@^0.2.2
         version: '@jsr/jlarky__gha-ts@0.2.2'
+      '@types/node':
+        specifier: 24.10.1
+        version: 24.10.1
       knip:
         specifier: 6.14.2
         version: 6.14.2
@@ -65,7 +68,10 @@ importers:
         version: 5.9.3
       vite-plus:
         specifier: 0.1.23
-        version: 0.1.23(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@types/node@24.10.1)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -1548,6 +1554,9 @@ packages:
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
 
+  '@types/node@24.10.1':
+    resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -1567,6 +1576,35 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
   '@voidzero-dev/vite-plus-core@0.1.23':
     resolution: {integrity: sha512-Twi+95cq1pObzkNR4u6lP7z4gPhtS0/vxeBAdbTvAeA12qlyyFED7mQZnAgaVIN3k1C1ve0997F3/ncUBAwQ8w==}
@@ -1817,6 +1855,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -2034,8 +2076,15 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -2584,6 +2633,9 @@ packages:
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
 
@@ -2757,6 +2809,9 @@ packages:
     resolution: {integrity: sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q==}
     engines: {node: '>=20'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
@@ -2774,6 +2829,9 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
@@ -2827,6 +2885,10 @@ packages:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -2863,6 +2925,9 @@ packages:
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -3033,6 +3098,47 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   volar-service-css@0.0.70:
     resolution: {integrity: sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==}
     peerDependencies:
@@ -3138,6 +3244,11 @@ packages:
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
     engines: {node: '>=4'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -3286,17 +3397,17 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/react@5.0.6(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(yaml@2.9.0)':
+  '@astrojs/react@5.0.6(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(yaml@2.9.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.0
       '@types/react': 19.2.15
       '@types/react-dom': 19.2.3(@types/react@19.2.15)
-      '@vitejs/plugin-react': 5.2.0(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+      '@vitejs/plugin-react': 5.2.0(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
       devalue: 5.8.1
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       ultrahtml: 1.6.0
-      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      vite: 7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4300,12 +4411,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
 
-  '@tailwindcss/vite@4.3.0(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.0(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      vite: 7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
 
   '@tanstack/query-core@5.100.14': {}
 
@@ -4397,6 +4508,10 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/node@24.10.1':
+    dependencies:
+      undici-types: 7.16.0
+
   '@types/react-dom@19.2.3(@types/react@19.2.15)':
     dependencies:
       '@types/react': 19.2.15
@@ -4409,7 +4524,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -4417,17 +4532,59 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      vite: 7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@voidzero-dev/vite-plus-core@0.1.23(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(yaml@2.9.0)':
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  '@voidzero-dev/vite-plus-core@0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(yaml@2.9.0)':
     dependencies:
       '@oxc-project/runtime': 0.133.0
       '@oxc-project/types': 0.133.0
       lightningcss: 1.32.0
       postcss: 8.5.15
     optionalDependencies:
+      '@types/node': 24.10.1
       esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.7.0
@@ -4452,11 +4609,11 @@ snapshots:
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.23':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.23(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)':
+  '@voidzero-dev/vite-plus-test@0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@voidzero-dev/vite-plus-core': 0.1.23(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(yaml@2.9.0)
+      '@voidzero-dev/vite-plus-core': 0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(yaml@2.9.0)
       es-module-lexer: 1.7.0
       obug: 2.1.1
       pixelmatch: 7.2.0
@@ -4466,8 +4623,10 @@ snapshots:
       tinybench: 2.9.0
       tinyexec: 1.2.2
       tinyglobby: 0.2.16
-      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      vite: 7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
       ws: 8.21.0
+    optionalDependencies:
+      '@types/node': 24.10.1
     transitivePeerDependencies:
       - '@arethetypeswrong/core'
       - '@tsdown/css'
@@ -4588,7 +4747,7 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  astro@6.4.2(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(yaml@2.9.0):
+  astro@6.4.2(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@astrojs/internal-helpers': 0.10.0
@@ -4640,8 +4799,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+      vite: 7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.4.3
@@ -4700,6 +4859,8 @@ snapshots:
   caniuse-lite@1.0.30001793: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -4915,7 +5076,13 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   eventemitter3@5.0.4: {}
+
+  expect-type@1.3.0: {}
 
   extend@3.0.2: {}
 
@@ -5631,7 +5798,7 @@ snapshots:
       '@oxc-resolver/binding-win32-arm64-msvc': 11.20.0
       '@oxc-resolver/binding-win32-x64-msvc': 11.20.0
 
-  oxfmt@0.52.0(vite-plus@0.1.23(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)):
+  oxfmt@0.52.0(vite-plus@0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -5654,7 +5821,7 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.52.0
       '@oxfmt/binding-win32-ia32-msvc': 0.52.0
       '@oxfmt/binding-win32-x64-msvc': 0.52.0
-      vite-plus: 0.1.23(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite-plus: 0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)
 
   oxlint-tsgolint@0.23.0:
     optionalDependencies:
@@ -5665,7 +5832,7 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 0.23.0
       '@oxlint-tsgolint/win32-x64': 0.23.0
 
-  oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.23(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)):
+  oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.67.0
       '@oxlint/binding-android-arm64': 1.67.0
@@ -5687,7 +5854,7 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.67.0
       '@oxlint/binding-win32-x64-msvc': 1.67.0
       oxlint-tsgolint: 0.23.0
-      vite-plus: 0.1.23(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite-plus: 0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)
 
   p-limit@7.3.0:
     dependencies:
@@ -5716,6 +5883,8 @@ snapshots:
       entities: 6.0.1
 
   path-browserify@1.0.1: {}
+
+  pathe@2.0.3: {}
 
   piccolore@0.1.3: {}
 
@@ -5967,6 +6136,8 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  siginfo@2.0.0: {}
+
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -5980,6 +6151,8 @@ snapshots:
   source-map-js@1.2.1: {}
 
   space-separated-tokens@2.0.2: {}
+
+  stackback@0.0.2: {}
 
   std-env@4.1.0: {}
 
@@ -6029,6 +6202,8 @@ snapshots:
 
   tinypool@2.1.0: {}
 
+  tinyrainbow@3.1.0: {}
+
   totalist@3.0.1: {}
 
   trim-lines@3.0.1: {}
@@ -6053,6 +6228,8 @@ snapshots:
   unbash@3.0.0: {}
 
   uncrypto@0.1.3: {}
+
+  undici-types@7.16.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -6148,14 +6325,14 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plus@0.1.23(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0):
+  vite-plus@0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:
       '@oxc-project/types': 0.133.0
       '@oxlint/plugins': 1.61.0
-      '@voidzero-dev/vite-plus-core': 0.1.23(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(yaml@2.9.0)
-      '@voidzero-dev/vite-plus-test': 0.1.23(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)
-      oxfmt: 0.52.0(vite-plus@0.1.23(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0))
-      oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.23(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0))
+      '@voidzero-dev/vite-plus-core': 0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(yaml@2.9.0)
+      '@voidzero-dev/vite-plus-test': 0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)
+      oxfmt: 0.52.0(vite-plus@0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0))
+      oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0))
       oxlint-tsgolint: 0.23.0
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.1.23
@@ -6198,7 +6375,7 @@ snapshots:
       - vite
       - yaml
 
-  vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0):
+  vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -6207,14 +6384,42 @@ snapshots:
       rollup: 4.60.4
       tinyglobby: 0.2.16
     optionalDependencies:
+      '@types/node': 24.10.1
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
       yaml: 2.9.0
 
-  vitefu@1.1.3(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)):
+  vitefu@1.1.3(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      vite: 7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+
+  vitest@4.1.5(@types/node@24.10.1)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.10.1
+    transitivePeerDependencies:
+      - msw
 
   volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:
@@ -6322,6 +6527,11 @@ snapshots:
   web-namespaces@2.0.1: {}
 
   which-pm-runs@1.1.0: {}
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4,6 +4,12 @@ import * as CircularSliderModule from "@fseehawer/react-circular-slider";
 import { Bullet } from "@nivo/bullet";
 import { QueryClient, QueryClientProvider, useMutation, useQuery } from "@tanstack/react-query";
 import { validateStoredLogEntries, validateStoredLogEntry, type LogEntry } from "./logEntry";
+import { ImportError, planExport, planImport, serializeExport } from "../lib/dataPortability";
+import {
+  getPersistentStorageStatus,
+  requestPersistentStorage,
+  type PersistentStorageStatus,
+} from "../lib/persistentStorage";
 
 // Assets in public/ are referenced by URL, not imported (Astro 3+ astro:assets).
 import "react-calendar/dist/Calendar.css";
@@ -353,7 +359,159 @@ const App: React.FC<{}> = () => {
         />
       </div>
       {!loadingDate && dataDate && <Statistic />}
+      <DataControls
+        days={dataAll}
+        onImported={async () => {
+          await refetch();
+          await queryClient.invalidateQueries({ queryKey: ["logs"] });
+        }}
+      />
     </div>
+  );
+};
+
+const DataControls: React.FC<{
+  days: LogEntry[] | undefined;
+  onImported: () => Promise<void>;
+}> = ({ days, onImported }) => {
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+  const [message, setMessage] = React.useState<{ tone: "ok" | "error"; text: string } | undefined>(
+    undefined,
+  );
+  const [storageStatus, setStorageStatus] = React.useState<PersistentStorageStatus>("unsupported");
+
+  React.useEffect(() => {
+    let active = true;
+    getPersistentStorageStatus()
+      .then((status) => active && setStorageStatus(status))
+      .catch(() => undefined);
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const handleExport = () => {
+    // Refuse to export when the store hasn't loaded, so a failed read can't be
+    // saved as a misleading empty backup.
+    const plan = planExport(days);
+    if (!plan.ok) {
+      setMessage({ tone: "error", text: plan.reason });
+      return;
+    }
+    const now = new Date();
+    const json = serializeExport(plan.days, now.toISOString());
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `bored-calendar-${now.toISOString().slice(0, 10)}.json`;
+    document.body.append(link);
+    link.click();
+    link.remove();
+    // Defer revocation so the download has begun across browsers.
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+    setMessage({ tone: "ok", text: `Exported ${plan.days.length} day(s).` });
+  };
+
+  const handleImport = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    // Reset so importing the same file twice still fires onChange.
+    event.target.value = "";
+    if (!file) {
+      return;
+    }
+    try {
+      const indexedDb = new IndexedDb("Calendar");
+      await indexedDb.createObjectStore(["Logs"]);
+      // Validate the file and merge it with existing days before any write, so a
+      // bad import never mutates storage and never deletes days absent from the
+      // file (merge is an upsert; imported days win on id collision).
+      const { merged, imported } = planImport(
+        await indexedDb.getAllValue("Logs"),
+        await file.text(),
+      );
+      await indexedDb.putBulkValue("Logs", merged);
+      await onImported();
+      setMessage({ tone: "ok", text: `Imported ${imported.length} day(s).` });
+    } catch (error) {
+      const text =
+        error instanceof ImportError
+          ? error.message
+          : "Something went wrong reading that file, so nothing was changed.";
+      setMessage({ tone: "error", text });
+    }
+  };
+
+  const handlePersist = async () => {
+    setStorageStatus(await requestPersistentStorage());
+  };
+
+  const storageLabel: Record<PersistentStorageStatus, string> = {
+    granted: "On — this browser has agreed to keep your data.",
+    denied: "Not yet granted — your browser may clear data under storage pressure.",
+    unsupported: "Not available in this browser.",
+  };
+
+  return (
+    <details className="rounded-2xl bg-grayish-500 px-4 py-4">
+      <summary className="cursor-pointer font-bold">Backup &amp; restore</summary>
+      <div className="text-sm text-grayish-800">
+        Your days live only on this device. Export a copy to keep them safe, or import a copy onto
+        another device. No account needed.
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <button
+          type="button"
+          className="rounded-2xl border border-bluish-500 bg-white px-3 py-2 text-sm font-bold text-grayish-900"
+          onClick={handleExport}
+        >
+          Export JSON
+        </button>
+        <button
+          type="button"
+          className="rounded-2xl border border-bluish-500 bg-white px-3 py-2 text-sm font-bold text-grayish-900"
+          onClick={() => fileInputRef.current?.click()}
+        >
+          Import JSON
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="application/json,.json"
+          className="hidden"
+          aria-label="Import a Bored Calendar JSON export"
+          onChange={(event) => {
+            handleImport(event).catch(() => undefined);
+          }}
+        />
+      </div>
+      {message && (
+        <output
+          className={
+            message.tone === "ok"
+              ? "mt-3 block rounded-xl bg-white p-3 text-sm text-grayish-900"
+              : "mt-3 block rounded-xl bg-white p-3 text-sm text-red-700"
+          }
+        >
+          {message.text}
+        </output>
+      )}
+      <div className="mt-4 border-t border-grayish-600 pt-3">
+        <div className="text-sm font-bold text-grayish-900">Persistent storage</div>
+        <div className="text-sm text-grayish-800">{storageLabel[storageStatus]}</div>
+        {storageStatus !== "granted" && storageStatus !== "unsupported" && (
+          <button
+            type="button"
+            className="mt-2 rounded-2xl border border-bluish-500 bg-white px-3 py-2 text-sm font-bold text-grayish-900"
+            onClick={() => {
+              handlePersist().catch(() => undefined);
+            }}
+          >
+            Keep my data on this device
+          </button>
+        )}
+      </div>
+    </details>
   );
 };
 

--- a/src/lib/dataPortability.test.ts
+++ b/src/lib/dataPortability.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from "vitest";
+import { type as arktype } from "arktype";
+import {
+  BoredExport,
+  ImportError,
+  MAX_DAILY_MINUTES,
+  SCHEMA_VERSION,
+  buildExport,
+  mergeDays,
+  parseExport,
+  planExport,
+  planImport,
+  serializeExport,
+} from "./dataPortability";
+import type { LogEntry } from "../components/logEntry";
+
+const sampleDays: LogEntry[] = [
+  { id: 1780704000000, date: "Jun 6, 2026", time: 20, reflection: "Watched clouds" },
+  { id: 1780790400000, date: "Jun 7, 2026", time: 5, reflection: "" },
+];
+
+const exportedAt = "2026-06-06T00:00:00.000Z";
+
+describe("serializeExport / buildExport", () => {
+  it("wraps days in the versioned envelope", () => {
+    const payload = buildExport(sampleDays, exportedAt);
+    expect(payload).toEqual({ schemaVersion: SCHEMA_VERSION, exportedAt, days: sampleDays });
+  });
+
+  it("produces JSON that round-trips through parseExport", () => {
+    const text = serializeExport(sampleDays, exportedAt);
+    const parsed = parseExport(text);
+    expect(parsed.days).toEqual(sampleDays);
+    expect(parsed.schemaVersion).toBe(SCHEMA_VERSION);
+    expect(parsed.exportedAt).toBe(exportedAt);
+  });
+
+  it("ends with a trailing newline (POSIX-friendly files)", () => {
+    expect(serializeExport([], exportedAt).endsWith("}\n")).toBe(true);
+  });
+});
+
+describe("parseExport", () => {
+  it("rejects non-JSON with a gentle message", () => {
+    expect(() => parseExport("not json{")).toThrow(ImportError);
+    expect(() => parseExport("not json{")).toThrow(/valid JSON/);
+  });
+
+  it("rejects a newer schema version with a version-specific message", () => {
+    const text = JSON.stringify({ schemaVersion: 99, exportedAt, days: [] });
+    expect(() => parseExport(text)).toThrow(/format version 99/);
+  });
+
+  it("rejects wrong-shape JSON without throwing a raw validation error", () => {
+    const text = JSON.stringify({ schemaVersion: SCHEMA_VERSION, exportedAt, days: [{ id: 1 }] });
+    expect(() => parseExport(text)).toThrow(ImportError);
+    expect(() => parseExport(text)).toThrow(/doesn't look like a Bored Calendar export/);
+  });
+
+  it("rejects extra top-level keys (strict envelope)", () => {
+    const text = JSON.stringify({
+      schemaVersion: SCHEMA_VERSION,
+      exportedAt,
+      days: [],
+      sneaky: true,
+    });
+    expect(() => parseExport(text)).toThrow(ImportError);
+  });
+
+  it("rejects extra keys inside a day entry", () => {
+    const text = JSON.stringify({
+      schemaVersion: SCHEMA_VERSION,
+      exportedAt,
+      days: [{ ...sampleDays[0], rogue: 1 }],
+    });
+    expect(() => parseExport(text)).toThrow(ImportError);
+  });
+
+  it("accepts a day without the optional reflection", () => {
+    const text = JSON.stringify({
+      schemaVersion: SCHEMA_VERSION,
+      exportedAt,
+      days: [{ id: 1780704000000, date: "Jun 6, 2026", time: 20 }],
+    });
+    expect(parseExport(text).days).toHaveLength(1);
+  });
+
+  it("rejects a non-integer (fractional) day id", () => {
+    const text = JSON.stringify({
+      schemaVersion: SCHEMA_VERSION,
+      exportedAt,
+      days: [{ id: 1.5, date: "Jun 6, 2026", time: 20 }],
+    });
+    expect(() => parseExport(text)).toThrow(ImportError);
+  });
+
+  it("rejects a negative time", () => {
+    const text = JSON.stringify({
+      schemaVersion: SCHEMA_VERSION,
+      exportedAt,
+      days: [{ id: 1780704000000, date: "Jun 6, 2026", time: -5 }],
+    });
+    expect(() => parseExport(text)).toThrow(ImportError);
+  });
+
+  it(`rejects a time above ${MAX_DAILY_MINUTES} minutes`, () => {
+    const text = JSON.stringify({
+      schemaVersion: SCHEMA_VERSION,
+      exportedAt,
+      days: [{ id: 1780704000000, date: "Jun 6, 2026", time: MAX_DAILY_MINUTES + 1 }],
+    });
+    expect(() => parseExport(text)).toThrow(ImportError);
+  });
+
+  it("rejects a non-integer time", () => {
+    const text = JSON.stringify({
+      schemaVersion: SCHEMA_VERSION,
+      exportedAt,
+      days: [{ id: 1780704000000, date: "Jun 6, 2026", time: 12.5 }],
+    });
+    expect(() => parseExport(text)).toThrow(ImportError);
+  });
+
+  it("accepts the boundary times 0 and the daily max", () => {
+    const text = JSON.stringify({
+      schemaVersion: SCHEMA_VERSION,
+      exportedAt,
+      days: [
+        { id: 1780704000000, date: "Jun 6, 2026", time: 0 },
+        { id: 1780790400000, date: "Jun 7, 2026", time: MAX_DAILY_MINUTES },
+      ],
+    });
+    expect(parseExport(text).days).toHaveLength(2);
+  });
+});
+
+describe("planExport (refuse export when store not loaded)", () => {
+  it("refuses when days are undefined (loading or read error)", () => {
+    const plan = planExport(undefined);
+    expect(plan.ok).toBe(false);
+    if (!plan.ok) {
+      expect(plan.reason).toMatch(/nothing was exported/);
+    }
+  });
+
+  it("allows export of an empty (but loaded) store", () => {
+    expect(planExport([])).toEqual({ ok: true, days: [] });
+  });
+
+  it("passes through loaded days", () => {
+    expect(planExport(sampleDays)).toEqual({ ok: true, days: sampleDays });
+  });
+});
+
+describe("planImport (validate existing + file, then merge)", () => {
+  const fileText = JSON.stringify(buildExport([sampleDays[1]], exportedAt));
+
+  it("merges file days over existing stored days", () => {
+    const plan = planImport([sampleDays[0]], fileText);
+    expect(plan.merged).toEqual([sampleDays[0], sampleDays[1]]);
+    expect(plan.imported).toEqual([sampleDays[1]]);
+  });
+
+  it("tolerates an empty existing store", () => {
+    const plan = planImport([], fileText);
+    expect(plan.merged).toEqual([sampleDays[1]]);
+  });
+
+  it("throws ImportError for a bad file before touching data", () => {
+    expect(() => planImport([sampleDays[0]], "not json{")).toThrow(ImportError);
+  });
+
+  it("throws if the existing stored data is itself corrupt", () => {
+    expect(() => planImport([{ id: "oops" }], fileText)).toThrow();
+  });
+});
+
+describe("mergeDays (upsert by id, imported wins)", () => {
+  it("adds new days and keeps existing ones", () => {
+    const existing = [sampleDays[0]];
+    const imported = [sampleDays[1]];
+    expect(mergeDays(existing, imported)).toEqual([sampleDays[0], sampleDays[1]]);
+  });
+
+  it("overwrites an existing day when ids collide", () => {
+    const existing = [sampleDays[0]];
+    const updated: LogEntry = { ...sampleDays[0], time: 40, reflection: "Updated" };
+    expect(mergeDays(existing, [updated])).toEqual([updated]);
+  });
+
+  it("never drops days missing from the import (no destructive replace)", () => {
+    const merged = mergeDays(sampleDays, []);
+    expect(merged).toEqual(sampleDays);
+  });
+
+  it("returns days sorted by id ascending", () => {
+    const merged = mergeDays([sampleDays[1]], [sampleDays[0]]);
+    expect(merged.map((d) => d.id)).toEqual([sampleDays[0].id, sampleDays[1].id]);
+  });
+});
+
+describe("BoredExport type guard", () => {
+  it("returns validated data for a well-formed payload", () => {
+    const result = BoredExport({ schemaVersion: SCHEMA_VERSION, exportedAt, days: sampleDays });
+    expect(result).toEqual({ schemaVersion: SCHEMA_VERSION, exportedAt, days: sampleDays });
+  });
+
+  it("flags a malformed payload with an arktype errors summary", () => {
+    const result = BoredExport({ schemaVersion: SCHEMA_VERSION });
+    expect(result).toBeInstanceOf(arktype.errors);
+    expect((result as { summary: string }).summary).toBeTruthy();
+  });
+});

--- a/src/lib/dataPortability.ts
+++ b/src/lib/dataPortability.ts
@@ -1,0 +1,141 @@
+import { type as arktype } from "arktype";
+import { validateStoredLogEntries, type LogEntry } from "../components/logEntry";
+
+// Bump this when the on-disk export shape changes in a non-additive way. Older
+// files are detected by `parseExport` so we can show a clear message (and, later,
+// run a migration) instead of failing with a confusing validation error.
+export const SCHEMA_VERSION = 1;
+
+// Largest daily total the UI can represent (mirrors `maxDailyMinutes` in App).
+export const MAX_DAILY_MINUTES = 240;
+
+// Import files are untrusted, so days are validated more strictly than data we
+// wrote ourselves: ids must be non-negative integer day-keys and times must be
+// whole minutes within the range the app can actually display. This is the gate
+// that makes "validate before write" meaningful for hand-edited files.
+const ImportDay = arktype({
+  id: "number.integer >= 0",
+  date: "string",
+  time: `0 <= number.integer <= ${MAX_DAILY_MINUTES}`,
+  "reflection?": "string",
+  "+": "reject",
+});
+
+// A Bored Calendar export is intentionally small and human-readable: a version,
+// a timestamp, and the list of logged days exactly as they live in IndexedDB.
+export const BoredExport = arktype({
+  schemaVersion: arktype.unit(SCHEMA_VERSION),
+  exportedAt: "string",
+  days: ImportDay.array(),
+  "+": "reject",
+});
+
+export type BoredExport = typeof BoredExport.infer;
+
+/** A user-facing error whose message is safe to show directly in the UI. */
+export class ImportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ImportError";
+  }
+}
+
+export function buildExport(days: LogEntry[], exportedAt: string): BoredExport {
+  return { schemaVersion: SCHEMA_VERSION, exportedAt, days };
+}
+
+/** Serialize logged days to the versioned JSON export string. */
+export function serializeExport(days: LogEntry[], exportedAt: string): string {
+  return `${JSON.stringify(buildExport(days, exportedAt), null, 2)}\n`;
+}
+
+/**
+ * Parse and validate an export file. Throws `ImportError` with a gentle,
+ * user-facing message for anything that isn't a well-formed current export, so
+ * callers never write partial/corrupt data to storage.
+ */
+export function parseExport(text: string): BoredExport {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new ImportError(
+      "This file isn't valid JSON. Please choose a Bored Calendar export file.",
+    );
+  }
+
+  // Detect a recognizable-but-newer export before strict validation so we can
+  // explain the version mismatch instead of dumping a shape error.
+  if (
+    parsed !== null &&
+    typeof parsed === "object" &&
+    "schemaVersion" in parsed &&
+    typeof (parsed as { schemaVersion: unknown }).schemaVersion === "number" &&
+    (parsed as { schemaVersion: number }).schemaVersion !== SCHEMA_VERSION
+  ) {
+    const found = (parsed as { schemaVersion: number }).schemaVersion;
+    throw new ImportError(
+      `This export uses format version ${found}, but this app understands version ${SCHEMA_VERSION}.`,
+    );
+  }
+
+  const result = BoredExport(parsed);
+  if (result instanceof arktype.errors) {
+    throw new ImportError(
+      "This file doesn't look like a Bored Calendar export, so nothing was changed.",
+    );
+  }
+  return result;
+}
+
+/**
+ * Merge imported days into existing days, keyed by day id (the day's midnight
+ * timestamp). Imported days win on conflict. This is an upsert, not a replace:
+ * importing never deletes days that aren't in the file, so a partial export can
+ * never wipe local history.
+ */
+export function mergeDays(existing: LogEntry[], imported: LogEntry[]): LogEntry[] {
+  const byId = new Map<number, LogEntry>();
+  for (const day of existing) {
+    byId.set(day.id, day);
+  }
+  for (const day of imported) {
+    byId.set(day.id, day);
+  }
+  return [...byId.values()].sort((a, b) => a.id - b.id);
+}
+
+export type ExportPlan = { ok: true; days: LogEntry[] } | { ok: false; reason: string };
+
+/**
+ * Decide whether an export is safe to produce. `days` is `undefined` while the
+ * store is still loading or if the read failed; in either case we refuse rather
+ * than hand back a misleading empty backup.
+ */
+export function planExport(days: LogEntry[] | undefined): ExportPlan {
+  if (days === undefined) {
+    return {
+      ok: false,
+      reason: "Your days are still loading or couldn't be read, so nothing was exported.",
+    };
+  }
+  return { ok: true, days };
+}
+
+export type ImportPlan = {
+  /** Full set to persist (existing upserted with imported). */
+  merged: LogEntry[];
+  /** Days that came from the file (for user-facing counts). */
+  imported: LogEntry[];
+};
+
+/**
+ * Validate the existing stored days and the imported file, then return the
+ * merged set to persist. Throws `ImportError` for a bad file before any write
+ * is attempted, so a failed import never mutates storage.
+ */
+export function planImport(existingRaw: unknown, fileText: string): ImportPlan {
+  const parsed = parseExport(fileText);
+  const existing = validateStoredLogEntries(existingRaw, "import.existing");
+  return { merged: mergeDays(existing, parsed.days), imported: parsed.days };
+}

--- a/src/lib/fixtures/example-export.json
+++ b/src/lib/fixtures/example-export.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": 1,
+  "exportedAt": "2026-06-06T00:00:00.000Z",
+  "days": [
+    {
+      "id": 1780704000000,
+      "date": "Jun 6, 2026",
+      "time": 20,
+      "reflection": "Sat on the balcony and watched the clouds drift."
+    },
+    {
+      "id": 1780790400000,
+      "date": "Jun 7, 2026",
+      "time": 5,
+      "reflection": ""
+    },
+    {
+      "id": 1780876800000,
+      "date": "Jun 8, 2026",
+      "time": 35,
+      "reflection": "Long walk with no podcast. Mind wandered to an old idea."
+    }
+  ]
+}

--- a/src/lib/fixtures/exampleExport.test.ts
+++ b/src/lib/fixtures/exampleExport.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { SCHEMA_VERSION, parseExport } from "../dataPortability";
+
+// Guards the dev/QA fixture: if the export format changes, this fails until the
+// example file is regenerated, so the documented example never drifts stale.
+describe("example-export.json fixture", () => {
+  const text = readFileSync(new URL("./example-export.json", import.meta.url), "utf8");
+
+  it("is a valid current-version export", () => {
+    const parsed = parseExport(text);
+    expect(parsed.schemaVersion).toBe(SCHEMA_VERSION);
+    expect(parsed.days.length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/persistentStorage.test.ts
+++ b/src/lib/persistentStorage.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getPersistentStorageStatus, requestPersistentStorage } from "./persistentStorage";
+
+const originalNavigator = globalThis.navigator;
+
+function stubStorage(storage: unknown) {
+  Object.defineProperty(globalThis, "navigator", {
+    value: storage === undefined ? {} : { storage },
+    configurable: true,
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "navigator", {
+    value: originalNavigator,
+    configurable: true,
+  });
+  vi.restoreAllMocks();
+});
+
+describe("getPersistentStorageStatus", () => {
+  it("reports unsupported when the StorageManager is missing", async () => {
+    stubStorage(undefined);
+    expect(await getPersistentStorageStatus()).toBe("unsupported");
+  });
+
+  it("reports granted when already persisted", async () => {
+    stubStorage({ persisted: vi.fn().mockResolvedValue(true) });
+    expect(await getPersistentStorageStatus()).toBe("granted");
+  });
+
+  it("reports denied when not persisted", async () => {
+    stubStorage({ persisted: vi.fn().mockResolvedValue(false) });
+    expect(await getPersistentStorageStatus()).toBe("denied");
+  });
+});
+
+describe("requestPersistentStorage", () => {
+  it("reports unsupported when persist() is unavailable", async () => {
+    stubStorage({ persisted: vi.fn().mockResolvedValue(false) });
+    expect(await requestPersistentStorage()).toBe("unsupported");
+  });
+
+  it("does not prompt again when already granted", async () => {
+    const persist = vi.fn().mockResolvedValue(true);
+    stubStorage({ persisted: vi.fn().mockResolvedValue(true), persist });
+    expect(await requestPersistentStorage()).toBe("granted");
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  it("returns granted when the browser grants the request", async () => {
+    stubStorage({
+      persisted: vi.fn().mockResolvedValue(false),
+      persist: vi.fn().mockResolvedValue(true),
+    });
+    expect(await requestPersistentStorage()).toBe("granted");
+  });
+
+  it("returns denied when the browser rejects the request", async () => {
+    stubStorage({
+      persisted: vi.fn().mockResolvedValue(false),
+      persist: vi.fn().mockResolvedValue(false),
+    });
+    expect(await requestPersistentStorage()).toBe("denied");
+  });
+});

--- a/src/lib/persistentStorage.ts
+++ b/src/lib/persistentStorage.ts
@@ -1,0 +1,35 @@
+// Browsers may evict IndexedDB for "best-effort" origins under storage pressure.
+// Asking for persistent storage tells the browser this data matters. Support and
+// the answer vary by browser, so we expose the outcome rather than assume it.
+export type PersistentStorageStatus = "granted" | "denied" | "unsupported";
+
+function storageManager(): StorageManager | undefined {
+  if (typeof navigator === "undefined") {
+    return undefined;
+  }
+  return navigator.storage;
+}
+
+/** Report whether storage is already persisted, without prompting. */
+export async function getPersistentStorageStatus(): Promise<PersistentStorageStatus> {
+  const storage = storageManager();
+  if (!storage?.persisted) {
+    return "unsupported";
+  }
+  return (await storage.persisted()) ? "granted" : "denied";
+}
+
+/**
+ * Request persistent storage. Returns the resulting status. Safe to call when
+ * unsupported (returns "unsupported") and idempotent when already granted.
+ */
+export async function requestPersistentStorage(): Promise<PersistentStorageStatus> {
+  const storage = storageManager();
+  if (!storage?.persist) {
+    return "unsupported";
+  }
+  if (storage.persisted && (await storage.persisted())) {
+    return "granted";
+  }
+  return (await storage.persist()) ? "granted" : "denied";
+}


### PR DESCRIPTION
Implements #21 — a local-only backup/restore path so users can trust the app with real boredom logs before any sync exists. No accounts, no cloud; IndexedDB stays the default data layer.

## What's included
- **Versioned JSON export** of all logged days (`schemaVersion: 1`, human-readable, trailing newline). Downloads as `bored-calendar-YYYY-MM-DD.json`.
- **Validated import** — the file is parsed and validated *before any write*:
  - must be valid JSON,
  - `schemaVersion` must match (a newer version gets a clear, version-specific message),
  - strict shape via arktype, rejecting extra keys at the envelope and per-day level,
  - days are bounds-checked (`id` non-negative integer, `time` an integer in `0–240`) since import files are untrusted.
- **Non-destructive merge** — import upserts by day `id` (imported wins on collision) and never deletes days absent from the file. There is intentionally no "replace all" mode.
- **Persistent storage** — requests `navigator.storage.persist()` and surfaces `granted` / `denied` / `unsupported`.
- **Backup & restore** UI section on `/app`.
- **Dev/QA fixture** (`src/lib/fixtures/example-export.json`) kept valid by a test.
- **Docs** — `docs/data-portability.md` documents the format and a concrete v1→v2 migration path.

## Design notes
- Data-loss-prone decisions live in pure, tested functions (`planExport`, `planImport`, `mergeDays`, `parseExport`) rather than the React glue. `planExport` refuses to export when the store hasn't loaded, so a failed read can't be saved as a misleadingly empty backup.
- `ImportError` carries only user-safe messages; any unexpected error falls back to a generic gentle message and changes nothing.

## Testing / CI
- Added **vitest** as a CI step (`vp test run`) and `vitest` + `@types/node` as devDeps so `astro check` type-checks the test files. `packageManager` is unchanged (still pnpm).
- 35 unit tests cover serialization round-trip, all rejection paths (bad JSON, wrong shape, extra keys, version mismatch, out-of-range/non-integer values), merge semantics, and the plan functions.
- All green locally: `vp check`, `vp run test` (astro check), `vp test run` (vitest), `vp run build`, `vp run knip`.

## Manual verification (production preview + headless browser)
- Backup & restore section renders and hydrates with a clean console.
- Driving the real file input: a valid file imported (`Imported 1 day(s).`) and the day was confirmed written to IndexedDB.
- A malformed file was rejected with *"This file isn't valid JSON…"* and left stored data unchanged.

## Out of scope (per issue non-goals)
No cloud sync, accounts, or paid-plan logic. Multi-device sync is explored separately in the stacked Jazz spike (#22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
