### PR TITLE
Spike Jazz for local-first multi-device sync (#22)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 import { defineConfig } from "astro/config";
 
 // https://astro.build/config
@@ -5,6 +7,10 @@ import react from "@astrojs/react";
 
 // Tailwind 4 is wired in through its Vite plugin, not an Astro integration.
 import tailwindcss from "@tailwindcss/vite";
+
+// Jazz sync PoC (issue #22). The plugin handles WASM/worker bundling and, in
+// dev, can register the schema with the sync server using the admin secret.
+import { jazzPlugin } from "jazz-tools/dev/vite";
 
 function getHostname(url) {
   if (!url) {
@@ -20,11 +26,40 @@ function getHostname(url) {
 
 const portlessTailscaleHost = getHostname(process.env.PORTLESS_TAILSCALE_URL);
 
+// Read .env into a plain object so build-time tooling (the Jazz plugin) can see
+// the unprefixed admin secret. We parse the file directly rather than import
+// Vite's loadEnv, which isn't a direct dependency. The file is absent in CI,
+// which is fine: the plugin still applies its build wiring (worker format / ssr
+// externals) and simply skips schema registration when no secret is present.
+function readDotEnv() {
+  const merged = { ...process.env };
+  try {
+    for (const line of readFileSync(new URL("./.env", import.meta.url), "utf8").split("\n")) {
+      const match = /^\s*([\w.-]+)\s*=\s*(.*)?\s*$/.exec(line);
+      if (match && !line.trimStart().startsWith("#")) {
+        merged[match[1]] = (match[2] ?? "").replace(/^["']|["']$/g, "").trim();
+      }
+    }
+  } catch {
+    // No .env (e.g. CI) — fall back to process.env only.
+  }
+  return merged;
+}
+
+const env = readDotEnv();
+
 // https://astro.build/config
 export default defineConfig({
   integrations: [react()],
   vite: {
-    plugins: [tailwindcss()],
+    plugins: [
+      tailwindcss(),
+      jazzPlugin({
+        appId: env.PUBLIC_JAZZ_APP_ID,
+        adminSecret: env.JAZZ_ADMIN_SECRET,
+        schemaDir: "src/lib/jazz",
+      }),
+    ],
     server: {
       allowedHosts: portlessTailscaleHost ? [portlessTailscaleHost] : [],
     },

--- a/docs/jazz-spike.md
+++ b/docs/jazz-spike.md
@@ -70,9 +70,13 @@ membership. This is the model the spike code encodes.
 > export const app = s.defineApp(appSchema);
 > ```
 >
-> Shapes mirror the issue #21 `ImportDay` schema so an export and a synced row are
-> the same data. Jazz owns its own string row `id`; our `dayKey` is what we upsert
-> by, exactly as IndexedDB keys by it today.
+> Shapes are analogous to the issue #21 `ImportDay` / local `LogEntry` so an export
+> and a synced row carry the same information, with a deliberate field mapping: the
+> local `id` (day key) becomes `dayKey` (Jazz owns its own string row `id`, which is
+> what we upsert by — exactly as IndexedDB keys by `id` today), and local `time`
+> becomes `minutes`. Note `reflection` is `string | null` here (Jazz `.optional()`)
+> vs `string | undefined` locally — a small normalization the real export/import
+> adapter would handle.
 
 > **API note — Jazz v2 alpha is a relational redesign.** The Group/Account/CoValue
 > primitives in the table above are the _classic_ Jazz mental model and the
@@ -210,15 +214,16 @@ Start on Jazz Cloud; keep self-hosting as a known, low-friction exit.
 **Verified (build + type + model):**
 
 - [x] The PoC compiles and type-checks against the real `jazz-tools` v2 types
-      (`vp run test` → 0 errors) — the `schema`/`db`/`useAll`/`useLocalFirstAuth`
-      API is used correctly, not mocked.
+      (`vp run test`, which runs `astro check` → 0 errors) — the
+      `schema`/`db`/`useAll`/`useLocalFirstAuth` API is used correctly, not mocked.
 - [x] `vp run build` produces a static site including `/jazz-poc`; the client
       bundle builds with the Jazz WASM runtime.
 - [x] In the browser, the page loads and **every** Jazz asset is fetched
       successfully, including `jazz_wasm_bg.wasm` (HTTP 200) and the sync client.
-- [x] The export format, strict validation, sensitivity classification, all three
-      restore-mode semantics (incl. error cases), v1 detection, and the
-      migration-away path — all covered by `src/lib/sync/jazzSync.test.ts`.
+- [x] The export/restore model — export format, strict validation, sensitivity
+      classification, all three restore-mode semantics (incl. error cases), v1
+      detection, and the migration-away path — is covered by
+      `src/lib/sync/jazzSync.test.ts`, run separately under vitest (`vp test run`).
 
 **Blocked on this machine (linux-arm64) — a real alpha-maturity finding:**
 

--- a/docs/jazz-spike.md
+++ b/docs/jazz-spike.md
@@ -1,13 +1,24 @@
 # Jazz spike — local-first multi-device sync (issue #22)
 
-Status: **spike / design + model layer.** This document plus `src/lib/sync/jazzSync.ts`
-(and its tests) are the deliverable. We deliberately did **not** add the
-`jazz-tools` runtime dependency or wire sync into the app yet — issue #21 keeps
-the free experience local-only, and a spike should let us decide _before_ taking
-on a sync engine. What we _have_ built is the part that a Jazz integration forces
-us to get right regardless of timing: the identity/secret model and the
-import/restore semantics, expressed as pure, tested code so the product
-decisions are concrete and reviewable.
+Status: **spike / running proof-of-concept.** The deliverable is three things:
+
+1. **A real, runtime Jazz integration** — `src/components/JazzPoc.tsx` +
+   `src/lib/jazz/schema.ts`, mounted on a dedicated `/jazz-poc` route
+   (`client:only`). It declares a Jazz v2 relational schema, reads/writes a synced
+   `boredDays` table, and exposes device-key backup/restore via Jazz's local-first
+   auth. This is what proves the engine actually works against the live sync server.
+2. **The export/restore + identity-sensitivity model** — `src/lib/sync/jazzSync.ts`
+   (pure, dependency-free, fully tested): how identity/secret material rides along
+   with a JSON export and what "restore this device" vs "add a new device" vs
+   "import data only" mean. This is the product layer we would build _on top of_ the
+   raw engine.
+3. **This decision doc** — the recommendation, the cost/maturity analysis, and the
+   verification findings (including a hard environment blocker, below).
+
+The `/jazz-poc` route is isolated: the main app (issue #21) stays local-only and
+account-free. Sync config comes from `PUBLIC_`-prefixed env vars; with no config
+the page renders setup instructions instead of crashing, so CI (which has no
+secrets) stays green.
 
 ## TL;DR recommendation
 
@@ -44,21 +55,37 @@ Modeling each device as its own Account that is a _member_ of the user's Group
 one device never compromises the others — we can revoke a single device's
 membership. This is the model the spike code encodes.
 
-> **Sketch of the CoValue schema (not yet wired in):**
+> **The actual v2 schema we shipped in the PoC** (`src/lib/jazz/schema.ts`):
 >
 > ```ts
-> const BoredDay = co.map({
->   id: z.number(),
->   date: z.string(),
->   time: z.number(),
->   reflection: z.string().optional(),
-> });
-> const BoredLog = co.record(z.string(), BoredDay); // keyed by day id
-> // BoredLog is owned by the user's Group; each device Account is a member.
+> import { schema as s } from "jazz-tools";
+> const appSchema = {
+>   boredDays: s.table({
+>     dayKey: s.int(), // local-midnight epoch ms — our logical day key
+>     date: s.string(),
+>     minutes: s.int(),
+>     reflection: s.string().optional(),
+>   }),
+> };
+> export const app = s.defineApp(appSchema);
 > ```
 >
-> Shapes mirror the issue #21 `ImportDay` schema so an export and a CoValue are
-> the same data.
+> Shapes mirror the issue #21 `ImportDay` schema so an export and a synced row are
+> the same data. Jazz owns its own string row `id`; our `dayKey` is what we upsert
+> by, exactly as IndexedDB keys by it today.
+
+> **API note — Jazz v2 alpha is a relational redesign.** The Group/Account/CoValue
+> primitives in the table above are the _classic_ Jazz mental model and the
+> longer-term permission story. The installed v2 alpha (`jazz-tools@2.0.0-alpha.50`)
+> instead exposes a **relational** API: `s.table(...)`, `db.insert/update/all`, and a
+> single per-device **local-first auth secret** (`useLocalFirstAuth().secret`) rather
+> than an explicit Account-per-device / Group-membership split. The PoC proves the
+> `deviceSecret` half of the mapping for real (the local seed _is_ the device's key,
+> `login()` restores it, `signOut()` forgets it). The richer multi-device
+> Group-authorization model in `jazzSync.ts` is therefore **design-ahead of the
+> alpha API** — it stays valid as the product target, but the exact v2 primitives for
+> multi-device authorization were still in flux at spike time and need re-confirming
+> against a later release.
 
 ## What this spike actually implements
 
@@ -106,8 +133,8 @@ Concretely in the UI:
 that is precisely Jazz's model: a local replica is the source of truth and sync
 is a background concern. The app stays usable offline and without an account; sync
 is additive. This preserves the issue #21 / #22 non-goal of not requiring accounts
-to use the app. _(Needs a live run to confirm the offline-then-reconnect replay
-behaves as documented — see "Not yet verified".)_
+to use the app. _(Needs a live run on a supported architecture to confirm the
+offline-then-reconnect replay behaves as documented — see "Verification" below.)_
 
 **Can we safely include identity/secret material in exports, or should
 secret-bearing exports require passphrase encryption?** A `secret-bearing` export
@@ -178,22 +205,54 @@ part of why Jazz is a low-risk bet.
 
 Start on Jazz Cloud; keep self-hosting as a known, low-friction exit.
 
-## Not yet verified (needs a live run before shipping sync)
+## Verification — what we ran, and a hard environment blocker
 
-The acceptance criteria below require the actual `jazz-tools` runtime and are the
-remaining work for a follow-up PR that adds the dependency behind a flag:
+**Verified (build + type + model):**
 
-- [ ] PoC: model the daily log as CoValues and run the app against a local Jazz replica.
-- [ ] Two browser profiles syncing the same log through Jazz Cloud (or a local server).
+- [x] The PoC compiles and type-checks against the real `jazz-tools` v2 types
+      (`vp run test` → 0 errors) — the `schema`/`db`/`useAll`/`useLocalFirstAuth`
+      API is used correctly, not mocked.
+- [x] `vp run build` produces a static site including `/jazz-poc`; the client
+      bundle builds with the Jazz WASM runtime.
+- [x] In the browser, the page loads and **every** Jazz asset is fetched
+      successfully, including `jazz_wasm_bg.wasm` (HTTP 200) and the sync client.
+- [x] The export format, strict validation, sensitivity classification, all three
+      restore-mode semantics (incl. error cases), v1 detection, and the
+      migration-away path — all covered by `src/lib/sync/jazzSync.test.ts`.
+
+**Blocked on this machine (linux-arm64) — a real alpha-maturity finding:**
+
+Jazz v2 alpha does not run end-to-end on `linux-arm64`, which is this VM's
+architecture. Two distinct gaps:
+
+1. **No Node native binding for `linux-arm64`.** The optional `jazz-napi` package
+   ships prebuilt binaries only for `darwin-{arm64,x64}`, `linux-x64-gnu`, and
+   `win32-x64-msvc` — there is **no `linux-arm64` binary**. So the Vite/dev
+   schema-registration tooling logs `[jazz] initialization failed: Cannot find
+native binding` on every `astro` invocation. Builds still complete (the browser
+   path uses WASM, not napi), but the Node-side admin tooling can't run here.
+2. **The browser WASM runtime hangs the page on arm64.** After `jazz_wasm_bg.wasm`
+   loads (confirmed 200), the renderer's main thread stops responding on
+   `/jazz-poc` — CDP `Runtime.evaluate`, `DOM.enable`, and screenshots all time
+   out, while the non-Jazz `/app` route in the same browser stays fully responsive.
+   The page never gets past Jazz runtime init.
+
+The net effect: the multi-device + offline acceptance criteria below could **not**
+be exercised in this environment. They are not code defects in the PoC (which
+type-checks, builds, and loads all assets) but a `jazz-tools@2.0.0-alpha.50` ×
+`linux-arm64` support gap. **Re-run the live validation on `darwin-arm64` or
+`linux-x64`** (both have native bindings and are the maintainers' tested targets):
+
+- [ ] Two browser profiles syncing the same log through the Jazz sync server.
 - [ ] Offline edit → reconnect → replay behaves as expected.
 - [ ] Observe real same-day conflict resolution (confirm LWW in practice).
-- [ ] Wire `applyRestore` output into real Account/Group provisioning + the
-      group-authorization handshake for _add-new-device_.
+- [ ] Confirm the v2 multi-device authorization primitives, then wire
+      `applyRestore` output into real provisioning (see the API note above).
 
-What _is_ verified here: the export format, strict validation, sensitivity
-classification, all three restore-mode semantics (including the error cases), v1
-detection, and the migration-away path — all covered by
-`src/lib/sync/jazzSync.test.ts`.
+This blocker **reinforces** the TL;DR recommendation: treat v2 as alpha, gate sync
+behind an opt-in flag, pin the version, and keep the issue #21 local-only floor as
+the always-available path. A sync engine that doesn't yet run on one of our
+developer architectures is not one to make load-bearing today.
 
 ## Relationship to issue #21
 

--- a/docs/jazz-spike.md
+++ b/docs/jazz-spike.md
@@ -1,0 +1,202 @@
+# Jazz spike — local-first multi-device sync (issue #22)
+
+Status: **spike / design + model layer.** This document plus `src/lib/sync/jazzSync.ts`
+(and its tests) are the deliverable. We deliberately did **not** add the
+`jazz-tools` runtime dependency or wire sync into the app yet — issue #21 keeps
+the free experience local-only, and a spike should let us decide _before_ taking
+on a sync engine. What we _have_ built is the part that a Jazz integration forces
+us to get right regardless of timing: the identity/secret model and the
+import/restore semantics, expressed as pure, tested code so the product
+decisions are concrete and reviewable.
+
+## TL;DR recommendation
+
+**Proceed with Jazz as the sync engine, but gate it behind an explicit opt-in
+and ship secret-bearing exports only with passphrase encryption.** Jazz fits the
+local-first product shape better than a backend-first option (Convex/Supabase),
+its cost at Bored Calendar's scale is negligible, and it is self-hostable if we
+ever need to leave the cloud. The main risk is maturity (**Jazz v2 is alpha as
+of 2026-06-06**), so the
+recommendation is: build the integration behind a flag, keep the IndexedDB +
+JSON import/export path (issue #21) as the always-available floor, and do a live
+two-device + offline validation run before exposing sync to users.
+
+## How Jazz maps onto Bored Calendar
+
+Jazz stores data as **CoValues** (collaborative values: `CoMap`, `CoList`, etc.)
+that live in a local replica (IndexedDB / OPFS in the browser) and sync through a
+server. Each CoValue is owned by an **Account** or a **Group**, and access is
+controlled by group membership. Authentication establishes which Account the
+current device acts as; the Account's secret is the key material that proves it.
+
+We map our existing model (`src/components/logEntry.ts`, one `LogEntry` per day,
+keyed by local-midnight epoch ms) like this:
+
+| Bored Calendar concept                   | Jazz primitive                                       | Notes                                              |
+| ---------------------------------------- | ---------------------------------------------------- | -------------------------------------------------- |
+| The person / data owner (`userId`)       | a **Group** that owns the log                        | members of the group can read/write the days       |
+| One device/install (`deviceId`)          | an **Account**                                       | each device is its own account with its own secret |
+| Device write capability (`deviceSecret`) | the Account's **Account Secret**                     | proves the device can act as itself                |
+| The daily boredom log                    | a `CoList`/`CoMap` of day entries owned by the Group | one entry per day, same `id` key as today          |
+
+Modeling each device as its own Account that is a _member_ of the user's Group
+(rather than sharing one master secret across devices) means losing or leaking
+one device never compromises the others — we can revoke a single device's
+membership. This is the model the spike code encodes.
+
+> **Sketch of the CoValue schema (not yet wired in):**
+>
+> ```ts
+> const BoredDay = co.map({
+>   id: z.number(),
+>   date: z.string(),
+>   time: z.number(),
+>   reflection: z.string().optional(),
+> });
+> const BoredLog = co.record(z.string(), BoredDay); // keyed by day id
+> // BoredLog is owned by the user's Group; each device Account is a member.
+> ```
+>
+> Shapes mirror the issue #21 `ImportDay` schema so an export and a CoValue are
+> the same data.
+
+## What this spike actually implements
+
+`src/lib/sync/jazzSync.ts` is dependency-free and models the export/restore
+surface:
+
+- **`SyncExport` (schemaVersion 2)** — the issue #21 v1 day list plus an optional
+  `identity` block (`userId`, `deviceId`, optional `deviceSecret`). It reuses the
+  strict, bounds-checked `ImportDay` schema from `dataPortability.ts`, so a sync
+  export validates days exactly as strictly as a local export. Sync exports use a
+  higher schema version so a v1-only reader rejects them clearly instead of
+  misreading them, and `parseSyncExport` detects a v1 file and routes it back to
+  the plain import path.
+- **Export sensitivity** — `classifyExport` labels a file `data-only`,
+  `account-linked`, or `secret-bearing`, and `redactSecret` strips the secret to
+  downgrade `secret-bearing` → `account-linked`. This is what lets the UI warn
+  appropriately and offer a "share-safe" export.
+- **The three restore modes** — `applyRestore(data, mode, generate)` is pure (id
+  generation is injected) and encodes the exact semantics below.
+
+### Restore-mode UX (the answer to "exact UX for restore vs add-new-device")
+
+| Mode                         | Requires                    | Resulting identity                                    | Group authorization                                 |
+| ---------------------------- | --------------------------- | ----------------------------------------------------- | --------------------------------------------------- |
+| **Restore this device**      | a **secret-bearing** export | adopt `userId` + `deviceId` + `deviceSecret` verbatim | none — it _is_ the device                           |
+| **Add this as a new device** | any export with an identity | keep `userId`, mint a fresh `deviceId`, **no** secret | **yes** — a trusted device must approve the new one |
+| **Import data only**         | nothing (identity ignored)  | mint fresh `userId` + `deviceId`                      | none — unlinked copy                                |
+
+Concretely in the UI:
+
+- _Restore this device_ is the "I lost my phone, restore from backup" flow. It
+  only makes sense if the backup carries the device secret, so we reject a
+  secret-less file with a message that points the user at "Add as a new device".
+- _Add this as a new device_ is "connect my laptop to the same account". The new
+  device provisions its own Account (its own secret), so it cannot write until an
+  already-trusted device authorizes it into the Group. The spike surfaces this as
+  `requiresGroupAuthorization: true` rather than pretending the device is
+  instantly trusted — that approval step is real in Jazz's permission model.
+- _Import data only_ is "copy these days into a brand-new identity" — useful for
+  trying the app, sharing a dataset, or starting clean.
+
+## Answers to the issue's questions
+
+**Can Jazz give us multi-device sync while keeping local-first behavior?** Yes —
+that is precisely Jazz's model: a local replica is the source of truth and sync
+is a background concern. The app stays usable offline and without an account; sync
+is additive. This preserves the issue #21 / #22 non-goal of not requiring accounts
+to use the app. _(Needs a live run to confirm the offline-then-reconnect replay
+behaves as documented — see "Not yet verified".)_
+
+**Can we safely include identity/secret material in exports, or should
+secret-bearing exports require passphrase encryption?** A `secret-bearing` export
+is equivalent to a password/seed-phrase backup: anyone holding the file can act
+as that device. **Recommendation: secret-bearing exports must be passphrase-
+encrypted** (e.g. wrap the `identity` block with WebCrypto AES-GCM + a
+user-supplied passphrase, PBKDF2/Argon2 KDF). `data-only` and `account-linked`
+exports can stay plaintext. The spike already separates these via
+`classifyExport`/`redactSecret`, so the encryption boundary is well-defined: only
+the `identity.deviceSecret` (and arguably the whole `identity`) needs wrapping.
+The default export button should produce a `data-only` or redacted file; emitting
+a secret requires an explicit, warned action.
+
+**What happens if browser storage is cleared and the user loses the local
+secret?** Without the Account Secret, the device can no longer prove it owns its
+data. If the Group still has another authorized device (e.g. the laptop), the
+data survives there and the wiped device can rejoin via _add-new-device_ +
+re-authorization. If it was the _only_ device and there is **no** secret-bearing
+backup, the synced data is effectively unrecoverable — there is no server-side
+password reset in a local-first model. This is why we (a) request persistent
+storage (issue #21's `persistentStorage.ts`, `navigator.storage.persist()`) to
+reduce eviction risk, and (b) prompt for a secret-bearing encrypted backup when
+sync is first enabled. The UI must state this trade-off plainly.
+
+**Same-day conflict / is last-write-wins acceptable for v1?** Bored Calendar's
+edits are single-user, low-frequency, and per-day (one `time` value + one
+`reflection` per day id). Jazz CoMaps resolve concurrent field writes
+last-write-wins. For our data, the realistic conflict is "edited the same day's
+minutes on two devices while offline" — LWW (last edit wins) is **acceptable for
+v1** and matches user expectation for a personal journal. If we later want to
+avoid silently losing a number, the per-day `time` could become an additive
+structure, but that is out of scope. _Document LWW in the sync UI._
+
+**Does Jazz Cloud pricing + alpha maturity feel acceptable?** Pricing is
+usage-based, scale-to-zero: **$0.15 / 1M I/O ops, $0.45 / GB-month storage, $0.09
+/ GB egress** (jazz.tools, as of 2026-06-06 — verify current rates before
+committing). Our data is tiny — a day entry is ~50–100 bytes,
+one write/day/user, occasional sync reads. Even **10,000 daily-active users**
+generate on the order of a few hundred thousand ops/month and well under a GB of
+storage/egress, i.e. **a few dollars/month** total; their own published example
+is ~$32/month for 1k MAU on _heavier_ usage, so Bored Calendar sits far below
+that. Cost is a non-issue. **Maturity is the real caveat: Jazz v2 is alpha.** That
+argues for: opt-in flag, keep the local-only floor, pin the version, and avoid
+making sync load-bearing until it stabilizes.
+
+**Is self-hosting realistic if needed?** Yes. Jazz's sync server is open source
+and self-hostable (`jazz-tools` server / sync-server). Because identity and data
+live in CoValues and the protocol is the same, self-hosting is a deployment
+decision, not a rewrite — we could start on Jazz Cloud and move to a self-hosted
+relay later. For a hobby-scale app, self-hosting a single sync node is realistic;
+the cloud is simply lower-ops to start.
+
+**Migration path if we later drop Jazz?** Strong, and demonstrated by the spike:
+`toLocalExport(text)` degrades any v2 sync export back to a valid v1 local-only
+export (issue #21 format), dropping all identity. Because the day shapes are
+identical between the two formats, "leave Jazz" is just "export, strip identity,
+keep using IndexedDB + JSON" — no data is trapped. That reversibility is a big
+part of why Jazz is a low-risk bet.
+
+## Hosted vs self-hosted summary
+
+|                          | Jazz Cloud (hosted)                | Self-hosted sync server                |
+| ------------------------ | ---------------------------------- | -------------------------------------- |
+| Ops burden               | none (zero-config)                 | run/monitor a node                     |
+| Cost                     | usage-based, ~$/month at our scale | infra cost of one small server         |
+| Data residency / control | Jazz's cloud                       | ours                                   |
+| Recommended for          | initial launch / spike → prod      | later, if control/residency demands it |
+
+Start on Jazz Cloud; keep self-hosting as a known, low-friction exit.
+
+## Not yet verified (needs a live run before shipping sync)
+
+The acceptance criteria below require the actual `jazz-tools` runtime and are the
+remaining work for a follow-up PR that adds the dependency behind a flag:
+
+- [ ] PoC: model the daily log as CoValues and run the app against a local Jazz replica.
+- [ ] Two browser profiles syncing the same log through Jazz Cloud (or a local server).
+- [ ] Offline edit → reconnect → replay behaves as expected.
+- [ ] Observe real same-day conflict resolution (confirm LWW in practice).
+- [ ] Wire `applyRestore` output into real Account/Group provisioning + the
+      group-authorization handshake for _add-new-device_.
+
+What _is_ verified here: the export format, strict validation, sensitivity
+classification, all three restore-mode semantics (including the error cases), v1
+detection, and the migration-away path — all covered by
+`src/lib/sync/jazzSync.test.ts`.
+
+## Relationship to issue #21
+
+This builds directly on the JSON import/export foundation. The sync export is a
+superset of the local export, reuses its `ImportDay` validation, and degrades back
+to it. See [`docs/data-portability.md`](./data-portability.md).

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "arktype": "2.2.0",
     "astro": "6.4.2",
     "idb": "8.0.3",
+    "jazz-tools": "2.0.0-alpha.50",
     "react": "19.2.6",
     "react-calendar": "6.0.1",
     "react-dom": "19.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       idb:
         specifier: 8.0.3
         version: 8.0.3
+      jazz-tools:
+        specifier: 2.0.0-alpha.50
+        version: 2.0.0-alpha.50(react@19.2.6)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -68,10 +71,10 @@ importers:
         version: 5.9.3
       vite-plus:
         specifier: 0.1.23
-        version: 0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 0.1.23(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@types/node@24.10.1)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -204,6 +207,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
@@ -420,6 +427,27 @@ packages:
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@garden-co/jazz-napi-darwin-arm64@2.0.0-alpha.50':
+    resolution: {integrity: sha512-y4AypuwDhqcw3blCtlK/add0AoUlPBwQ43mwXVztfokNgqgNyEPplHypY2566iKcisOPJwx2epE7sC97MEinNQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@garden-co/jazz-napi-darwin-x64@2.0.0-alpha.50':
+    resolution: {integrity: sha512-l5wKrFqvBRhahddv4BeBJk4mg/i2ZVHQO4lZSADfLWyn2uHpFzOpDvc3oToZcdmS3u+SlrcrVSUK8t/h0d15Hw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@garden-co/jazz-napi-linux-x64-gnu@2.0.0-alpha.50':
+    resolution: {integrity: sha512-r0+02d8AmBwWqljvKOCGJdtrjpVCOMW3a1XtICUqww6hfzPqvY02K/QgbADthmZt/I6is4lqFZ+pM3MmkBXQKQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@garden-co/jazz-napi-win32-x64-msvc@2.0.0-alpha.50':
+    resolution: {integrity: sha512-7/K3SrVMc6HqhXXR4v95hnmNejD/Jm+tRLuJrrbubnPhGshZPgIflq+WJqOv/5ilmOdUx6TAD1sSk2EkQihXjA==}
+    cpu: [x64]
+    os: [win32]
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -641,6 +669,76 @@ packages:
     resolution: {integrity: sha512-weoEGR3xAetV4k2P6k96cdamGzKQ5F2Pq+uyDaHr1P3HYArM879Pl+x+TkU0aWjP6wgUZPx/GOBiV1Hb1JxIqg==}
     peerDependencies:
       react: ^16.14 || ^17.0 || ^18.0 || ^19.0
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
+
+  '@opentelemetry/api-logs@0.216.0':
+    resolution: {integrity: sha512-KmGTgvxTJ0J01d4mOeX1wMV5NUTNf9HebIuOOGDfIn0a/IrnXIQbOnlylDyl9tkDv4h0DUpdI/GqCdLzfTkUXg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.7.1':
+    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-logs-otlp-http@0.216.0':
+    resolution: {integrity: sha512-8SUzQY/aExKkz6Ab3vOf6gu690Xk4wHH90dGwXinejQzazn5HCIRR7yPVU/2fEuiZ73R92MU4qI3djHfYP7NJg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.216.0':
+    resolution: {integrity: sha512-DhWjvj0PUPFwFnhOEivpum8sJzj6FTuyx88zff+oHVLUhfd6cLyw4AIai/F4j0PZqYZBFuMT/OTMUd9wdXnBEQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.216.0':
+    resolution: {integrity: sha512-sSnvb5f+FYa4mfYxj03rmmUh+aDwo3jok62dgIWUDw8ZCUPzEbgtv/YhZyKUSlKNNey7Uc5xmJgmtTLLIV6UDQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.216.0':
+    resolution: {integrity: sha512-g4Rb6sAsxQAo11eDjixfKxelruBsQFdJ8Wo23FCj7D6OXbidgXMu2xaRSYs4RdlomzAXSJuc86RcS3xmE8A6uA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.7.1':
+    resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.216.0':
+    resolution: {integrity: sha512-KB3rcwQuitq0JbbsCcNdqMhRJX3kArAYz/ovb0jGRaBQAIrt2roik3xQXuhYxS37zx0jSkUZcJu1z3Y2UCxbDA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.7.1':
+    resolution: {integrity: sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.7.1':
+    resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
+    engines: {node: '>=14'}
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
@@ -1166,6 +1264,36 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+
   '@react-spring/animated@9.4.5':
     resolution: {integrity: sha512-KWqrtvJSMx6Fj9nMJkhTwM9r6LIriExDRV6YHZV9HKQsaolUFppgkOXpC+rsL1JEtEvKv6EkLLmSqHTnuYjiIA==}
     peerDependencies:
@@ -1342,6 +1470,12 @@ packages:
     resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
     cpu: [x64]
     os: [win32]
+
+  '@scure/base@2.2.0':
+    resolution: {integrity: sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==}
+
+  '@scure/bip39@2.2.0':
+    resolution: {integrity: sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==}
 
   '@shikijs/core@4.1.0':
     resolution: {integrity: sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ==}
@@ -2239,9 +2373,52 @@ packages:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
+  jazz-napi@2.0.0-alpha.50:
+    resolution: {integrity: sha512-Cgvasmx9Z1xFh06uWkmBatxkarCCRbDCh725y1U8mnaIllQAcaUiYtG9vWOpwe2nKOAUQuw6FF+ENZSeRIVSmQ==}
+
+  jazz-tools@2.0.0-alpha.50:
+    resolution: {integrity: sha512-f3IQCV4YZRUzYAyU5v73mgPKujW8tyZeZsx0S9h4qAd+gHbzyVmdNPcqjP1vAeTtB6IF8yVhWoEMIXm+ddGV9w==}
+    engines: {node: '>=22.12'}
+    hasBin: true
+    peerDependencies:
+      better-auth: ^1.5.5
+      expo: '>=54'
+      expo-crypto: '>=14.0.0'
+      expo-secure-store: '>=14.0.0'
+      jazz-rn: 2.0.0-alpha.50
+      react: '>=19'
+      react-native: '>=0.76'
+      svelte: ^5.0.0
+      vue: ^3.5.0
+    peerDependenciesMeta:
+      better-auth:
+        optional: true
+      expo:
+        optional: true
+      expo-crypto:
+        optional: true
+      expo-secure-store:
+        optional: true
+      jazz-rn:
+        optional: true
+      react:
+        optional: true
+      react-native:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+
+  jazz-wasm@2.0.0-alpha.50:
+    resolution: {integrity: sha512-flXPzWpTdML1HjtJ+YaGAY5Wzv5S1zZgzVM+emvfY4R2xVKa27hPf5+vhk905iZdwAVh/pv4lMdq6afFvnBsaA==}
+
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2254,6 +2431,10 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -2354,6 +2535,9 @@ packages:
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -2654,6 +2838,10 @@ packages:
     resolution: {integrity: sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==}
     hasBin: true
 
+  pluralize-esm@9.0.5:
+    resolution: {integrity: sha512-Kb2dcpMsIutFw2hYrN0EhsAXOUJTd6FVMIxvNAkZCMQLVt9NGZqQczvGpYDxNWCZeCWLHUPxQIBudWzt1h7VVA==}
+    engines: {node: '>=14.0.0'}
+
   pngjs@7.0.0:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
@@ -2673,6 +2861,10 @@ packages:
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  protobufjs@8.0.1:
+    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
+    engines: {node: '>=12.0.0'}
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
@@ -2898,6 +3090,9 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -3241,6 +3436,10 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  web-streams-polyfill@4.3.0:
+    resolution: {integrity: sha512-/Gnggvj9oSrEvJbDyyPtAnxBt5fGQM2iWOKQNu7ie1OxDgK40iZpyV3TKaRiEzVj1oA1UxKnEy9XPXh6PW3eVw==}
+    engines: {node: '>= 8'}
+
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
     engines: {node: '>=4'}
@@ -3523,6 +3722,8 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/runtime@7.29.7': {}
+
   '@babel/template@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -3683,6 +3884,18 @@ snapshots:
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
+
+  '@garden-co/jazz-napi-darwin-arm64@2.0.0-alpha.50':
+    optional: true
+
+  '@garden-co/jazz-napi-darwin-x64@2.0.0-alpha.50':
+    optional: true
+
+  '@garden-co/jazz-napi-linux-x64-gnu@2.0.0-alpha.50':
+    optional: true
+
+  '@garden-co/jazz-napi-win32-x64-msvc@2.0.0-alpha.50':
+    optional: true
 
   '@img/colour@1.1.0':
     optional: true
@@ -3920,6 +4133,83 @@ snapshots:
       react: 19.2.6
     transitivePeerDependencies:
       - react-dom
+
+  '@noble/hashes@2.2.0': {}
+
+  '@opentelemetry/api-logs@0.216.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/exporter-logs-otlp-http@0.216.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.216.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.216.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.216.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-exporter-base@0.216.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.216.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.216.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.216.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      protobufjs: 8.0.1
+
+  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-logs@0.216.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.216.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
 
   '@oslojs/encoding@1.1.0': {}
 
@@ -4190,6 +4480,28 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
+
   '@react-spring/animated@9.4.5(react@19.2.6)':
     dependencies:
       '@react-spring/shared': 9.4.5(react@19.2.6)
@@ -4307,6 +4619,13 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.60.4':
     optional: true
+
+  '@scure/base@2.2.0': {}
+
+  '@scure/bip39@2.2.0':
+    dependencies:
+      '@noble/hashes': 2.2.0
+      '@scure/base': 2.2.0
 
   '@shikijs/core@4.1.0':
     dependencies:
@@ -4609,7 +4928,7 @@ snapshots:
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.23':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)':
+  '@voidzero-dev/vite-plus-test@0.1.23(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
@@ -4626,6 +4945,7 @@ snapshots:
       vite: 7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
       ws: 8.21.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 24.10.1
     transitivePeerDependencies:
       - '@arethetypeswrong/core'
@@ -5272,7 +5592,39 @@ snapshots:
     dependencies:
       is-inside-container: 1.0.0
 
+  jazz-napi@2.0.0-alpha.50:
+    optionalDependencies:
+      '@garden-co/jazz-napi-darwin-arm64': 2.0.0-alpha.50
+      '@garden-co/jazz-napi-darwin-x64': 2.0.0-alpha.50
+      '@garden-co/jazz-napi-linux-x64-gnu': 2.0.0-alpha.50
+      '@garden-co/jazz-napi-win32-x64-msvc': 2.0.0-alpha.50
+    optional: true
+
+  jazz-tools@2.0.0-alpha.50(react@19.2.6):
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/exporter-logs-otlp-http': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@scure/bip39': 2.2.0
+      '@standard-schema/spec': 1.1.0
+      esbuild: 0.27.7
+      jazz-wasm: 2.0.0-alpha.50
+      jose: 6.2.3
+      json-schema-to-ts: 3.1.1
+      pluralize-esm: 9.0.5
+      web-streams-polyfill: 4.3.0
+    optionalDependencies:
+      jazz-napi: 2.0.0-alpha.50
+      react: 19.2.6
+
+  jazz-wasm@2.0.0-alpha.50: {}
+
   jiti@2.7.0: {}
+
+  jose@6.2.3: {}
 
   js-tokens@4.0.0: {}
 
@@ -5281,6 +5633,11 @@ snapshots:
       argparse: 2.0.1
 
   jsesc@3.1.0: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
 
   json-schema-traverse@1.0.0: {}
 
@@ -5359,6 +5716,8 @@ snapshots:
       lightningcss-win32-x64-msvc: 1.32.0
 
   lodash@4.18.1: {}
+
+  long@5.3.2: {}
 
   longest-streak@3.1.0: {}
 
@@ -5798,7 +6157,7 @@ snapshots:
       '@oxc-resolver/binding-win32-arm64-msvc': 11.20.0
       '@oxc-resolver/binding-win32-x64-msvc': 11.20.0
 
-  oxfmt@0.52.0(vite-plus@0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)):
+  oxfmt@0.52.0(vite-plus@0.1.23(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -5821,7 +6180,7 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.52.0
       '@oxfmt/binding-win32-ia32-msvc': 0.52.0
       '@oxfmt/binding-win32-x64-msvc': 0.52.0
-      vite-plus: 0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite-plus: 0.1.23(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)
 
   oxlint-tsgolint@0.23.0:
     optionalDependencies:
@@ -5832,7 +6191,7 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 0.23.0
       '@oxlint-tsgolint/win32-x64': 0.23.0
 
-  oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)):
+  oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.23(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.67.0
       '@oxlint/binding-android-arm64': 1.67.0
@@ -5854,7 +6213,7 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.67.0
       '@oxlint/binding-win32-x64-msvc': 1.67.0
       oxlint-tsgolint: 0.23.0
-      vite-plus: 0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite-plus: 0.1.23(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)
 
   p-limit@7.3.0:
     dependencies:
@@ -5898,6 +6257,8 @@ snapshots:
     dependencies:
       pngjs: 7.0.0
 
+  pluralize-esm@9.0.5: {}
+
   pngjs@7.0.0: {}
 
   postcss@8.5.15:
@@ -5911,6 +6272,21 @@ snapshots:
   prismjs@1.30.0: {}
 
   property-information@7.1.0: {}
+
+  protobufjs@8.0.1:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 24.10.1
+      long: 5.3.2
 
   radix3@1.1.2: {}
 
@@ -6210,6 +6586,8 @@ snapshots:
 
   trough@2.2.0: {}
 
+  ts-algebra@2.0.0: {}
+
   tslib@2.8.1:
     optional: true
 
@@ -6325,14 +6703,14 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plus@0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0):
+  vite-plus@0.1.23(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:
       '@oxc-project/types': 0.133.0
       '@oxlint/plugins': 1.61.0
       '@voidzero-dev/vite-plus-core': 0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(yaml@2.9.0)
-      '@voidzero-dev/vite-plus-test': 0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)
-      oxfmt: 0.52.0(vite-plus@0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0))
-      oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.23(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0))
+      '@voidzero-dev/vite-plus-test': 0.1.23(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)
+      oxfmt: 0.52.0(vite-plus@0.1.23(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0))
+      oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.23(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.7.0)(typescript@5.9.3)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0))
       oxlint-tsgolint: 0.23.0
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.1.23
@@ -6394,7 +6772,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
 
-  vitest@4.1.5(@types/node@24.10.1)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.10.1)(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
@@ -6417,6 +6795,7 @@ snapshots:
       vite: 7.3.3(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 24.10.1
     transitivePeerDependencies:
       - msw
@@ -6525,6 +6904,8 @@ snapshots:
       loose-envify: 1.4.0
 
   web-namespaces@2.0.1: {}
+
+  web-streams-polyfill@4.3.0: {}
 
   which-pm-runs@1.1.0: {}
 

--- a/src/components/JazzPoc.tsx
+++ b/src/components/JazzPoc.tsx
@@ -1,0 +1,210 @@
+import { useState } from "react";
+import { JazzProvider, useAll, useDb, useLocalFirstAuth, useSession } from "jazz-tools/react";
+import { app, type BoredDayRow } from "../lib/jazz/schema";
+
+/**
+ * Jazz v2 sync proof-of-concept (issue #22, Option A).
+ *
+ * This is a real, runtime Jazz integration — NOT the dependency-free model from
+ * the earlier spike commit. It is mounted only on the dedicated `/jazz-poc`
+ * route (client:only) so the main local-only app is untouched. Sync config comes
+ * from PUBLIC_ env vars; with no config the page explains how to set it up rather
+ * than crashing, which keeps CI (no secrets) green.
+ *
+ * Identity mapping proven here (matches docs/jazz-spike.md):
+ *   useLocalFirstAuth().secret  -> the device seed  (our `deviceSecret`)
+ *   login(secret)               -> "restore this device" from a backup
+ *   signOut()                   -> forget this device's identity
+ */
+
+const APP_ID = import.meta.env.PUBLIC_JAZZ_APP_ID as string | undefined;
+const SERVER_URL = import.meta.env.PUBLIC_JAZZ_SERVER_URL as string | undefined;
+
+function midnightKey(date: Date): number {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+}
+
+function NotConfigured() {
+  return (
+    <div className="mx-auto max-w-xl p-6">
+      <h1 className="text-2xl font-semibold">Jazz sync PoC</h1>
+      <p className="mt-3 text-stone-600">
+        This proof-of-concept needs a Jazz app id and sync server. Create a <code>.env</code> with:
+      </p>
+      <pre className="mt-3 rounded bg-stone-100 p-3 text-sm">
+        PUBLIC_JAZZ_APP_ID=…{"\n"}PUBLIC_JAZZ_SERVER_URL=https://v2.sync.jazz.tools/
+      </pre>
+      <p className="mt-3 text-sm text-stone-500">
+        Without it the page stays inert — the main local-only app is unaffected.
+      </p>
+    </div>
+  );
+}
+
+function SyncStatus() {
+  const session = useSession();
+  return (
+    <p className="text-xs text-stone-500">
+      {session
+        ? `Connected as ${session.user_id ?? "local identity"}`
+        : "Local only (not yet synced)"}
+    </p>
+  );
+}
+
+function DeviceKey() {
+  const { secret, signOut } = useLocalFirstAuth();
+  const [restoreInput, setRestoreInput] = useState("");
+  const { login } = useLocalFirstAuth();
+  const [revealed, setRevealed] = useState(false);
+
+  return (
+    <section className="mt-6 rounded border border-stone-200 p-4">
+      <h2 className="font-medium">This device&rsquo;s key</h2>
+      <p className="mt-1 text-sm text-stone-600">
+        Back this up to restore on another device. Anyone with it can act as this device — treat it
+        like a password.
+      </p>
+      <div className="mt-2 flex items-center gap-2">
+        <code className="block grow truncate rounded bg-stone-100 p-2 text-xs">
+          {secret ? (revealed ? secret : "•".repeat(24)) : "(none yet)"}
+        </code>
+        <button
+          type="button"
+          className="rounded border px-2 py-1 text-xs"
+          onClick={() => setRevealed((v) => !v)}
+        >
+          {revealed ? "Hide" : "Reveal"}
+        </button>
+      </div>
+
+      <div className="mt-4">
+        <label className="text-sm font-medium" htmlFor="restore">
+          Restore this device from a backed-up key
+        </label>
+        <textarea
+          id="restore"
+          aria-label="Restore this device from a backed-up key"
+          className="mt-1 w-full rounded border p-2 text-xs"
+          rows={2}
+          value={restoreInput}
+          onChange={(e) => setRestoreInput(e.target.value)}
+          placeholder="Paste a device key…"
+        />
+        <div className="mt-2 flex gap-2">
+          <button
+            type="button"
+            className="rounded bg-stone-800 px-3 py-1 text-xs text-white disabled:opacity-40"
+            disabled={!restoreInput.trim()}
+            onClick={() => void login(restoreInput.trim())}
+          >
+            Restore this device
+          </button>
+          <button
+            type="button"
+            className="rounded border px-3 py-1 text-xs"
+            onClick={() => void signOut()}
+          >
+            Forget identity
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Days() {
+  const db = useDb();
+  const days = useAll(app.boredDays) as BoredDayRow[] | undefined;
+  const [minutes, setMinutes] = useState(15);
+
+  async function logToday() {
+    const now = new Date();
+    const dayKey = midnightKey(now);
+    const existing = days?.find((d) => d.dayKey === dayKey);
+    const date = now.toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+    if (existing) {
+      db.update(app.boredDays, existing.id, { minutes });
+    } else {
+      db.insert(app.boredDays, { dayKey, date, minutes });
+    }
+  }
+
+  return (
+    <section className="mt-6">
+      <h2 className="font-medium">Boredom log (synced via Jazz)</h2>
+      <div className="mt-2 flex items-center gap-2">
+        <input
+          type="number"
+          min={0}
+          max={240}
+          aria-label="Minutes spent bored today"
+          className="w-24 rounded border p-2"
+          value={minutes}
+          onChange={(e) => setMinutes(Number(e.target.value))}
+        />
+        <button
+          type="button"
+          className="rounded bg-stone-800 px-3 py-1 text-sm text-white"
+          onClick={() => void logToday()}
+        >
+          Log today
+        </button>
+      </div>
+      <ul className="mt-4 space-y-1">
+        {days === undefined && <li className="text-sm text-stone-400">Loading…</li>}
+        {days?.length === 0 && <li className="text-sm text-stone-400">No days logged yet.</li>}
+        {days
+          ?.slice()
+          .sort((a, b) => b.dayKey - a.dayKey)
+          .map((d) => (
+            <li key={d.id} className="flex justify-between rounded bg-stone-50 px-3 py-2 text-sm">
+              <span>{d.date}</span>
+              <span className="tabular-nums">{d.minutes} min</span>
+            </li>
+          ))}
+      </ul>
+    </section>
+  );
+}
+
+function Inner() {
+  return (
+    <div className="mx-auto max-w-xl p-6">
+      <header className="flex items-baseline justify-between">
+        <h1 className="text-2xl font-semibold">Jazz sync PoC</h1>
+        <SyncStatus />
+      </header>
+      <p className="mt-1 text-sm text-stone-500">
+        Open this page in two browser profiles to watch days sync. Edit offline, then reconnect to
+        see the queued writes replay.
+      </p>
+      <Days />
+      <DeviceKey />
+    </div>
+  );
+}
+
+export default function JazzPoc() {
+  const { secret, isLoading } = useLocalFirstAuth();
+
+  if (!APP_ID || !SERVER_URL) {
+    return <NotConfigured />;
+  }
+  if (isLoading) {
+    return <div className="p-6 text-stone-500">Loading local identity…</div>;
+  }
+
+  return (
+    <JazzProvider
+      config={{ appId: APP_ID, serverUrl: SERVER_URL, secret: secret ?? undefined }}
+      fallback={<div className="p-6 text-stone-500">Connecting to Jazz…</div>}
+    >
+      <Inner />
+    </JazzProvider>
+  );
+}

--- a/src/components/JazzPoc.tsx
+++ b/src/components/JazzPoc.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { JazzProvider, useAll, useDb, useLocalFirstAuth, useSession } from "jazz-tools/react";
-import { app, type BoredDayRow } from "../lib/jazz/schema";
+import { app } from "../lib/jazz/schema";
 
 /**
  * Jazz v2 sync proof-of-concept (issue #22, Option A).
@@ -53,9 +53,8 @@ function SyncStatus() {
 }
 
 function DeviceKey() {
-  const { secret, signOut } = useLocalFirstAuth();
+  const { secret, login, signOut } = useLocalFirstAuth();
   const [restoreInput, setRestoreInput] = useState("");
-  const { login } = useLocalFirstAuth();
   const [revealed, setRevealed] = useState(false);
 
   return (
@@ -115,7 +114,8 @@ function DeviceKey() {
 
 function Days() {
   const db = useDb();
-  const days = useAll(app.boredDays) as BoredDayRow[] | undefined;
+  // useAll is typed from the table's row type, so `days` is BoredDayRow[] | undefined.
+  const days = useAll(app.boredDays);
   const [minutes, setMinutes] = useState(15);
 
   async function logToday() {
@@ -145,7 +145,7 @@ function Days() {
           aria-label="Minutes spent bored today"
           className="w-24 rounded border p-2"
           value={minutes}
-          onChange={(e) => setMinutes(Number(e.target.value))}
+          onChange={(e) => setMinutes(Number(e.target.value) || 0)}
         />
         <button
           type="button"
@@ -190,6 +190,9 @@ function Inner() {
 }
 
 export default function JazzPoc() {
+  // Exactly one hook above the guards below. APP_ID/SERVER_URL are module
+  // constants, so hook order is stable per mount — keep any new hooks above the
+  // early returns to preserve that.
   const { secret, isLoading } = useLocalFirstAuth();
 
   if (!APP_ID || !SERVER_URL) {

--- a/src/lib/dataPortability.test.ts
+++ b/src/lib/dataPortability.test.ts
@@ -67,6 +67,11 @@ describe("parseExport", () => {
     expect(() => parseExport(text)).toThrow(ImportError);
   });
 
+  it("rejects a smuggled __proto__ key that strict arktype alone would miss", () => {
+    const text = `{"schemaVersion":${SCHEMA_VERSION},"exportedAt":"${exportedAt}","days":[],"__proto__":{"polluted":true}}`;
+    expect(() => parseExport(text)).toThrow(ImportError);
+  });
+
   it("rejects extra keys inside a day entry", () => {
     const text = JSON.stringify({
       schemaVersion: SCHEMA_VERSION,

--- a/src/lib/dataPortability.ts
+++ b/src/lib/dataPortability.ts
@@ -13,7 +13,7 @@ export const MAX_DAILY_MINUTES = 240;
 // wrote ourselves: ids must be non-negative integer day-keys and times must be
 // whole minutes within the range the app can actually display. This is the gate
 // that makes "validate before write" meaningful for hand-edited files.
-const ImportDay = arktype({
+export const ImportDay = arktype({
   id: "number.integer >= 0",
   date: "string",
   time: `0 <= number.integer <= ${MAX_DAILY_MINUTES}`,
@@ -40,6 +40,34 @@ export class ImportError extends Error {
   }
 }
 
+/**
+ * Parse JSON from an untrusted file while refusing `__proto__` keys.
+ * `JSON.parse` materializes a literal `"__proto__"` key as a real own property
+ * that arktype's strict `"+": "reject"` does NOT catch, so without this an
+ * attacker-crafted file could smuggle an extra key (or pollute objects derived
+ * from the result). The reviver runs for every nested key, so this guards the
+ * whole tree. Throws `ImportError` (never a raw `SyntaxError`).
+ */
+export function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text, (key, value) => {
+      if (key === "__proto__") {
+        throw new ImportError(
+          "This file isn't valid JSON. Please choose a Bored Calendar export file.",
+        );
+      }
+      return value;
+    });
+  } catch (error) {
+    if (error instanceof ImportError) {
+      throw error;
+    }
+    throw new ImportError(
+      "This file isn't valid JSON. Please choose a Bored Calendar export file.",
+    );
+  }
+}
+
 export function buildExport(days: LogEntry[], exportedAt: string): BoredExport {
   return { schemaVersion: SCHEMA_VERSION, exportedAt, days };
 }
@@ -55,14 +83,7 @@ export function serializeExport(days: LogEntry[], exportedAt: string): string {
  * callers never write partial/corrupt data to storage.
  */
 export function parseExport(text: string): BoredExport {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(text);
-  } catch {
-    throw new ImportError(
-      "This file isn't valid JSON. Please choose a Bored Calendar export file.",
-    );
-  }
+  const parsed = safeJsonParse(text);
 
   // Detect a recognizable-but-newer export before strict validation so we can
   // explain the version mismatch instead of dumping a shape error.

--- a/src/lib/jazz/schema.ts
+++ b/src/lib/jazz/schema.ts
@@ -25,6 +25,3 @@ const appSchema = {
 type AppSchema = s.Schema<typeof appSchema>;
 
 export const app: s.App<AppSchema> = s.defineApp(appSchema);
-
-/** A stored boredom-day row, including Jazz's own `id`. */
-export type BoredDayRow = s.RowOf<typeof app.boredDays>;

--- a/src/lib/jazz/schema.ts
+++ b/src/lib/jazz/schema.ts
@@ -1,0 +1,30 @@
+import { schema as s } from "jazz-tools";
+
+/**
+ * Jazz v2 schema for the Bored Calendar sync PoC (issue #22, Option A).
+ *
+ * This is the real, runtime Jazz relational schema — one row per logged day —
+ * mirroring the local `LogEntry` shape (`src/components/logEntry.ts`). Jazz owns
+ * its own string row `id`; our logical day key (local-midnight epoch ms) lives in
+ * `dayKey` so we can upsert by day the same way IndexedDB keys by it.
+ *
+ * `minutes` is an INTEGER column left on the default last-write-wins merge — the
+ * conflict behavior the spike doc argues is acceptable for a personal daily
+ * journal. Jazz also supports counter-style merges on integers if we ever want
+ * additive resolution instead.
+ */
+const appSchema = {
+  boredDays: s.table({
+    dayKey: s.int(),
+    date: s.string(),
+    minutes: s.int(),
+    reflection: s.string().optional(),
+  }),
+};
+
+type AppSchema = s.Schema<typeof appSchema>;
+
+export const app: s.App<AppSchema> = s.defineApp(appSchema);
+
+/** A stored boredom-day row, including Jazz's own `id`. */
+export type BoredDayRow = s.RowOf<typeof app.boredDays>;

--- a/src/lib/sync/jazzSync.test.ts
+++ b/src/lib/sync/jazzSync.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from "vitest";
+import { ImportError, SCHEMA_VERSION } from "../dataPortability";
+import {
+  SYNC_SCHEMA_VERSION,
+  SyncExport,
+  applyRestore,
+  classifyExport,
+  parseSyncExport,
+  redactSecret,
+  toLocalExport,
+  type DeviceIdentity,
+  type IdGenerator,
+  type SyncExport as SyncExportType,
+} from "./jazzSync";
+
+const exportedAt = "2026-06-06T00:00:00.000Z";
+
+const day = { id: 1780704000000, date: "Jun 6, 2026", time: 20, reflection: "Watched clouds" };
+
+function syncExport(identity?: DeviceIdentity): SyncExportType {
+  return {
+    schemaVersion: SYNC_SCHEMA_VERSION,
+    exportedAt,
+    days: [day],
+    ...(identity ? { identity } : {}),
+  };
+}
+
+// Deterministic id generator so restore output is fully assertable.
+const generate: IdGenerator = {
+  userId: () => "new-user",
+  deviceId: () => "new-device",
+};
+
+describe("classifyExport", () => {
+  it("classifies an export with no identity as data-only", () => {
+    expect(classifyExport(syncExport())).toBe("data-only");
+  });
+
+  it("classifies an export with userId but no secret as account-linked", () => {
+    expect(classifyExport(syncExport({ userId: "u1", deviceId: "d1" }))).toBe("account-linked");
+  });
+
+  it("classifies an export carrying a device secret as secret-bearing", () => {
+    expect(classifyExport(syncExport({ userId: "u1", deviceId: "d1", deviceSecret: "s1" }))).toBe(
+      "secret-bearing",
+    );
+  });
+});
+
+describe("redactSecret", () => {
+  it("strips the device secret from a secret-bearing export", () => {
+    const redacted = redactSecret(syncExport({ userId: "u1", deviceId: "d1", deviceSecret: "s1" }));
+    expect(redacted.identity?.deviceSecret).toBeUndefined();
+    expect(classifyExport(redacted)).toBe("account-linked");
+  });
+
+  it("keeps userId/deviceId while redacting", () => {
+    const redacted = redactSecret(syncExport({ userId: "u1", deviceId: "d1", deviceSecret: "s1" }));
+    expect(redacted.identity).toEqual({ userId: "u1", deviceId: "d1" });
+  });
+
+  it("returns the export unchanged when there is no secret to strip", () => {
+    const linked = syncExport({ userId: "u1", deviceId: "d1" });
+    expect(redactSecret(linked)).toBe(linked);
+    const dataOnly = syncExport();
+    expect(redactSecret(dataOnly)).toBe(dataOnly);
+  });
+
+  it("does not mutate the original export", () => {
+    const original = syncExport({ userId: "u1", deviceId: "d1", deviceSecret: "s1" });
+    redactSecret(original);
+    expect(original.identity?.deviceSecret).toBe("s1");
+  });
+});
+
+describe("applyRestore — restore-this-device", () => {
+  it("adopts the full saved identity from a secret-bearing export", () => {
+    const result = applyRestore(
+      syncExport({ userId: "u1", deviceId: "d1", deviceSecret: "s1" }),
+      "restore-this-device",
+      generate,
+    );
+    expect(result.identity).toEqual({ userId: "u1", deviceId: "d1", deviceSecret: "s1" });
+    expect(result.requiresGroupAuthorization).toBe(false);
+    expect(result.days).toEqual([day]);
+  });
+
+  it("throws when the export has no identity", () => {
+    expect(() => applyRestore(syncExport(), "restore-this-device", generate)).toThrow(ImportError);
+  });
+
+  it("throws when the export has an identity but no secret", () => {
+    expect(() =>
+      applyRestore(syncExport({ userId: "u1", deviceId: "d1" }), "restore-this-device", generate),
+    ).toThrow(ImportError);
+  });
+});
+
+describe("applyRestore — add-new-device", () => {
+  it("keeps the user but mints a fresh device id and drops the secret", () => {
+    const result = applyRestore(
+      syncExport({ userId: "u1", deviceId: "d1", deviceSecret: "s1" }),
+      "add-new-device",
+      generate,
+    );
+    expect(result.identity).toEqual({ userId: "u1", deviceId: "new-device" });
+    expect(result.requiresGroupAuthorization).toBe(true);
+    expect(result.days).toEqual([day]);
+  });
+
+  it("works from an account-linked (secret-less) export", () => {
+    const result = applyRestore(
+      syncExport({ userId: "u1", deviceId: "d1" }),
+      "add-new-device",
+      generate,
+    );
+    expect(result.identity).toEqual({ userId: "u1", deviceId: "new-device" });
+    expect(result.requiresGroupAuthorization).toBe(true);
+  });
+
+  it("throws when there is no identity to join", () => {
+    expect(() => applyRestore(syncExport(), "add-new-device", generate)).toThrow(ImportError);
+  });
+});
+
+describe("applyRestore — import-data-only", () => {
+  it("mints a brand-new, unlinked identity regardless of the file's identity", () => {
+    const result = applyRestore(
+      syncExport({ userId: "u1", deviceId: "d1", deviceSecret: "s1" }),
+      "import-data-only",
+      generate,
+    );
+    expect(result.identity).toEqual({ userId: "new-user", deviceId: "new-device" });
+    expect(result.requiresGroupAuthorization).toBe(false);
+    expect(result.days).toEqual([day]);
+  });
+
+  it("works when the file carries no identity at all", () => {
+    const result = applyRestore(syncExport(), "import-data-only", generate);
+    expect(result.identity).toEqual({ userId: "new-user", deviceId: "new-device" });
+  });
+});
+
+describe("applyRestore — does not mutate its input", () => {
+  it("restore-this-device returns copies, so mutating the result is safe", () => {
+    const data = syncExport({ userId: "u1", deviceId: "d1", deviceSecret: "s1" });
+    const result = applyRestore(data, "restore-this-device", generate);
+    result.days.push({ id: 2, date: "Jun 7, 2026", time: 1 });
+    (result.identity as { deviceSecret?: string }).deviceSecret = "tampered";
+    expect(data.days).toEqual([day]);
+    expect(data.identity).toEqual({ userId: "u1", deviceId: "d1", deviceSecret: "s1" });
+  });
+
+  it("import-data-only returns a copy of days", () => {
+    const data = syncExport();
+    const result = applyRestore(data, "import-data-only", generate);
+    result.days.push({ id: 2, date: "Jun 7, 2026", time: 1 });
+    expect(data.days).toEqual([day]);
+  });
+});
+
+describe("parseSyncExport", () => {
+  it("round-trips a well-formed sync export", () => {
+    const text = JSON.stringify(syncExport({ userId: "u1", deviceId: "d1", deviceSecret: "s1" }));
+    const parsed = parseSyncExport(text);
+    expect(parsed.days).toEqual([day]);
+    expect(parsed.identity).toEqual({ userId: "u1", deviceId: "d1", deviceSecret: "s1" });
+  });
+
+  it("accepts a sync export with no identity", () => {
+    expect(parseSyncExport(JSON.stringify(syncExport())).identity).toBeUndefined();
+  });
+
+  it("rejects non-JSON with a gentle message", () => {
+    expect(() => parseSyncExport("not json{")).toThrow(ImportError);
+    expect(() => parseSyncExport("not json{")).toThrow(/valid JSON/);
+  });
+
+  it("detects a v1 local-only export and points to the standard import", () => {
+    const v1 = JSON.stringify({ schemaVersion: SCHEMA_VERSION, exportedAt, days: [day] });
+    expect(() => parseSyncExport(v1)).toThrow(/local-only export/);
+  });
+
+  it("rejects wrong-shape JSON without leaking a raw validation error", () => {
+    const text = JSON.stringify({
+      schemaVersion: SYNC_SCHEMA_VERSION,
+      exportedAt,
+      days: [{ id: 1 }],
+    });
+    expect(() => parseSyncExport(text)).toThrow(/sync export/);
+  });
+
+  it("rejects extra top-level keys (strict envelope)", () => {
+    const text = JSON.stringify({ ...syncExport(), sneaky: true });
+    expect(() => parseSyncExport(text)).toThrow(ImportError);
+  });
+
+  it("rejects extra keys inside the identity block", () => {
+    const text = JSON.stringify({
+      schemaVersion: SYNC_SCHEMA_VERSION,
+      exportedAt,
+      days: [day],
+      identity: { userId: "u1", deviceId: "d1", rogue: true },
+    });
+    expect(() => parseSyncExport(text)).toThrow(ImportError);
+  });
+
+  it("rejects a smuggled __proto__ key that would slip past strict validation", () => {
+    const text = `{"schemaVersion":${SYNC_SCHEMA_VERSION},"exportedAt":"${exportedAt}","days":[],"__proto__":{"polluted":true}}`;
+    expect(() => parseSyncExport(text)).toThrow(ImportError);
+  });
+});
+
+describe("toLocalExport (migration away from Jazz)", () => {
+  it("degrades a sync export to a valid v1 local export, dropping identity", () => {
+    const text = JSON.stringify(syncExport({ userId: "u1", deviceId: "d1", deviceSecret: "s1" }));
+    const local = toLocalExport(text);
+    expect(local.schemaVersion).toBe(SCHEMA_VERSION);
+    expect(local.exportedAt).toBe(exportedAt);
+    expect(local.days).toEqual([day]);
+    expect(local).not.toHaveProperty("identity");
+  });
+
+  it("propagates ImportError for a non-sync file", () => {
+    const v1 = JSON.stringify({ schemaVersion: SCHEMA_VERSION, exportedAt, days: [day] });
+    expect(() => toLocalExport(v1)).toThrow(/local-only export/);
+  });
+});
+
+describe("SyncExport type guard", () => {
+  it("validates a well-formed payload", () => {
+    const result = SyncExport(syncExport());
+    expect(result).toEqual(syncExport());
+  });
+});

--- a/src/lib/sync/jazzSync.ts
+++ b/src/lib/sync/jazzSync.ts
@@ -1,0 +1,213 @@
+import { type as arktype } from "arktype";
+import { type LogEntry } from "../../components/logEntry";
+import {
+  ImportDay,
+  ImportError,
+  SCHEMA_VERSION,
+  parseExport,
+  safeJsonParse,
+} from "../dataPortability";
+
+/**
+ * Jazz sync spike — model layer (issue #22).
+ *
+ * This module is intentionally dependency-free and is NOT wired into the running
+ * app: the free experience stays local-only (issue #21). It models the product
+ * decisions that a Jazz integration forces — how identity/secret material rides
+ * along with a JSON export, and what "restore this device" vs "add a new device"
+ * vs "import data only" actually mean — so they can be evaluated and tested
+ * before committing to the `jazz-tools` runtime. See docs/jazz-spike.md.
+ *
+ * Mapping to Jazz primitives (see docs for detail):
+ *   userId       -> a Jazz Group that owns the boredom-log CoValues (the data owner)
+ *   deviceId     -> a Jazz Account for one install/device
+ *   deviceSecret -> that Account's Account Secret (lets the device act as itself)
+ * Each device is its own Account (its own secret) and a member of the userId
+ * Group, so losing one device never leaks a shared master secret.
+ */
+
+// Sync-aware exports use a distinct, higher schema version than the local-only
+// v1 export so old readers reject them clearly rather than misinterpreting them.
+export const SYNC_SCHEMA_VERSION = 2;
+
+/** Identity/secret material a device may hold. `deviceSecret` is sensitive. */
+const DeviceIdentity = arktype({
+  userId: "string",
+  deviceId: "string",
+  "deviceSecret?": "string",
+  "+": "reject",
+});
+export type DeviceIdentity = typeof DeviceIdentity.infer;
+
+/** A sync-aware export: the v1 day list plus optional identity. */
+export const SyncExport = arktype({
+  schemaVersion: arktype.unit(SYNC_SCHEMA_VERSION),
+  exportedAt: "string",
+  days: ImportDay.array(),
+  "identity?": DeviceIdentity,
+  "+": "reject",
+});
+export type SyncExport = typeof SyncExport.infer;
+
+/**
+ * How sensitive an export is to share, driven by what identity material it
+ * carries:
+ *   "data-only"      no identity — safe to share; can only become a new identity
+ *   "account-linked" userId (+deviceId) but no secret — reveals the data owner,
+ *                    cannot write without being granted Group membership
+ *   "secret-bearing" includes deviceSecret — anyone holding it can act as that
+ *                    device's account; treat like a password backup
+ */
+export type ExportSensitivity = "data-only" | "account-linked" | "secret-bearing";
+
+export function classifyExport(data: SyncExport): ExportSensitivity {
+  if (!data.identity) {
+    return "data-only";
+  }
+  return data.identity.deviceSecret ? "secret-bearing" : "account-linked";
+}
+
+/**
+ * Strip the device secret so the export is safe to share/transport. Returns the
+ * input unchanged when there is nothing to redact (no identity, or no secret);
+ * otherwise returns a shallow copy with `deviceSecret` removed.
+ */
+export function redactSecret(data: SyncExport): SyncExport {
+  if (!data.identity?.deviceSecret) {
+    return data;
+  }
+  const { deviceSecret: _omit, ...identity } = data.identity;
+  return { ...data, identity };
+}
+
+export type RestoreMode = "restore-this-device" | "add-new-device" | "import-data-only";
+
+export type IdGenerator = {
+  /** New data-owner id (Jazz Group). */
+  userId: () => string;
+  /** New device/account id (Jazz Account). */
+  deviceId: () => string;
+};
+
+export type RestoreResult = {
+  /** Boredom days to load locally. */
+  days: LogEntry[];
+  /** Identity this device should adopt after the restore. */
+  identity: DeviceIdentity;
+  /**
+   * True when the resulting device still needs to be authorized into the
+   * existing user's Group by an already-trusted device (add-new-device without
+   * a secret in the file). The spike surfaces this rather than papering over it.
+   */
+  requiresGroupAuthorization: boolean;
+  notes: string[];
+};
+
+/**
+ * Compute the local identity + data that a given restore mode produces from a
+ * parsed sync export. Pure: callers inject id generation so this is fully
+ * testable and free of ambient randomness.
+ *
+ * - restore-this-device: adopt userId, deviceId, and deviceSecret from the file
+ *   (a true backup restore). Requires a secret-bearing export.
+ * - add-new-device: keep the userId (same data owner), mint a fresh deviceId and
+ *   drop any secret — this device provisions its own account and must be granted
+ *   Group membership by a trusted device.
+ * - import-data-only: ignore identity entirely; mint a fresh userId and deviceId
+ *   so the data lives under a brand-new, unlinked identity.
+ */
+export function applyRestore(
+  data: SyncExport,
+  mode: RestoreMode,
+  generate: IdGenerator,
+): RestoreResult {
+  switch (mode) {
+    case "restore-this-device": {
+      if (!data.identity) {
+        throw new ImportError(
+          "This file has no saved account, so there is nothing to restore. Try “Import data only”.",
+        );
+      }
+      if (!data.identity.deviceSecret) {
+        throw new ImportError(
+          "This backup is missing its device secret, so this device can’t be fully restored. Try “Add this as a new device”.",
+        );
+      }
+      // Copy days and identity so a caller mutating the result can't corrupt
+      // the parsed export it was derived from.
+      return {
+        days: [...data.days],
+        identity: { ...data.identity },
+        requiresGroupAuthorization: false,
+        notes: ["Restored the saved account, device, and secret from the backup."],
+      };
+    }
+    case "add-new-device": {
+      if (!data.identity) {
+        throw new ImportError("This file has no saved account to join. Try “Import data only”.");
+      }
+      return {
+        days: [...data.days],
+        identity: { userId: data.identity.userId, deviceId: generate.deviceId() },
+        requiresGroupAuthorization: true,
+        notes: [
+          "Kept the existing user and minted a new device id with no secret.",
+          "A trusted device must approve this new device before it can sync.",
+        ],
+      };
+    }
+    case "import-data-only": {
+      return {
+        days: [...data.days],
+        identity: { userId: generate.userId(), deviceId: generate.deviceId() },
+        requiresGroupAuthorization: false,
+        notes: ["Created a fresh, unlinked identity and copied the days into it."],
+      };
+    }
+  }
+}
+
+/**
+ * Parse a sync-aware export. Mirrors `parseExport` (issue #21): validates JSON,
+ * version, and shape before anything is trusted, and throws `ImportError` with a
+ * user-safe message otherwise. A v1 (local-only) export is detected and reported
+ * so the caller can fall back to the plain import path.
+ */
+export function parseSyncExport(text: string): SyncExport {
+  const parsed = safeJsonParse(text);
+
+  const version =
+    parsed !== null && typeof parsed === "object" && "schemaVersion" in parsed
+      ? (parsed as { schemaVersion: unknown }).schemaVersion
+      : undefined;
+
+  if (version === SCHEMA_VERSION) {
+    throw new ImportError(
+      "This is a local-only export without sync data. Import it with the standard import instead.",
+    );
+  }
+
+  const result = SyncExport(parsed);
+  if (result instanceof arktype.errors) {
+    throw new ImportError(
+      "This file doesn't look like a Bored Calendar sync export, so nothing was changed.",
+    );
+  }
+  return result;
+}
+
+/**
+ * Build a v1 (local-only) export from a sync export, dropping all identity. This
+ * is the documented migration path *away* from Jazz: a sync export always
+ * degrades cleanly to the issue #21 format.
+ */
+export function toLocalExport(text: string): ReturnType<typeof parseExport> {
+  const sync = parseSyncExport(text);
+  return parseExport(
+    JSON.stringify({
+      schemaVersion: SCHEMA_VERSION,
+      exportedAt: sync.exportedAt,
+      days: sync.days,
+    }),
+  );
+}

--- a/src/pages/jazz-poc.astro
+++ b/src/pages/jazz-poc.astro
@@ -1,0 +1,11 @@
+---
+import Layout from "../layouts/Layout.astro";
+import JazzPoc from "../components/JazzPoc";
+---
+
+<Layout title="Jazz sync PoC — Bored Calendar">
+  <main class="mx-auto flex min-h-screen max-w-xl flex-col px-4 py-6">
+    <a href="/" class="mb-2 text-sm text-grayish-800 hover:text-grayish-900">← Home</a>
+    <JazzPoc client:only="react" />
+  </main>
+</Layout>


### PR DESCRIPTION
Closes #22.

**Stacked on #23** (JSON import/export) — base branch is `feature/json-import-export`, not `main`. Review/merge #23 first; the diff here is only the sync spike.

## What this is

A **spike that actually runs Jazz.** It now has three parts:

1. **A real, runtime Jazz v2 integration** on a dedicated `/jazz-poc` route (`client:only`) — it exercises the sync engine, not just describes it.
2. **The export/restore + identity-sensitivity model** (`jazzSync.ts`) layered on top — the product decisions a Jazz integration forces, as pure tested code.
3. **A decision doc** with the recommendation, cost/maturity analysis, and verification findings.

Per the issue's non-goals, the **main app stays local-only and account-free** — sync lives only on the isolated `/jazz-poc` route. The free experience (issue #21) is untouched.

## What's in it

- **`src/lib/jazz/schema.ts`** — a Jazz v2 relational schema: a synced `boredDays` table (`dayKey`, `date`, `minutes`, optional `reflection`) mirroring the local `LogEntry` shape so an export and a synced row are the same data.
- **`src/components/JazzPoc.tsx` + `src/pages/jazz-poc.astro`** — the running PoC: reads/writes the synced table via `useAll` / `useDb`, and exposes device-key backup/restore via `useLocalFirstAuth` (the local seed *is* the device key; `login()` restores, `signOut()` forgets). Renders setup instructions instead of crashing when sync env vars are absent, so CI (no secrets) stays green.
- **`astro.config.mjs`** — wires `jazzPlugin` for WASM/worker bundling and reads `.env` via a dependency-free parser. Sync config uses `PUBLIC_` vars (client-visible by design); the admin secret is unprefixed (server-only) and never reaches the bundle. `.env` is gitignored and not committed.
- **`src/lib/sync/jazzSync.ts`** — the export/restore model (unchanged): `SyncExport` (schemaVersion 2), `classifyExport` / `redactSecret` (export sensitivity + secret stripping), `applyRestore` (three restore modes with injected id generation), `parseSyncExport` / `toLocalExport` (v1 detection + migrate-*away* path).
- **`src/lib/dataPortability.ts`** — hardened untrusted-file parsing with `safeJsonParse`, which rejects smuggled `__proto__` keys that slip past arktype's strict `"+": "reject"` (verified: arktype alone doesn't catch them). Reused in `parseExport`.
- **`docs/jazz-spike.md`** — the full decision doc: Jazz↔Bored mapping, the v2 relational-API reality vs the classic Account/Group model, answers to every question in the issue, and the verification findings below.

## Recommendation (see doc for full reasoning)

Proceed with Jazz behind an explicit opt-in; keep the local-only IndexedDB + JSON path as the always-available floor; passphrase-encrypt any secret-bearing export. Main caveat: **Jazz v2 is alpha** (as of 2026-06-06).

## Verified vs blocked

**Verified:** the PoC type-checks against the real `jazz-tools` v2 types (0 errors), builds a static site including `/jazz-poc`, and in-browser every Jazz asset loads (incl. `jazz_wasm_bg.wasm`, HTTP 200). `jazzSync.test.ts` covers export format, `__proto__` rejection, all three restore modes + error/immutability cases, v1 detection, and the migrate-away path (64 tests total).

**Blocked on linux-arm64 — a real alpha-maturity finding:** Jazz v2 alpha has **no `linux-arm64` native binding** (`jazz-napi` ships darwin/linux-x64/win-x64 only), so the Node-side schema tooling logs `Cannot find native binding`; and the **browser WASM runtime hangs the page on arm64** after the wasm loads (the non-Jazz `/app` route in the same browser stays responsive). So the two-device + offline acceptance criteria couldn't be run here — they need **darwin-arm64 or linux-x64**. This isn't a PoC defect (it compiles, builds, loads all assets); it reinforces the "treat v2 as alpha, gate behind a flag" recommendation.

## Manual verification

```
vp check        # format + lint — clean
vp run test     # astro check (type-check) — 0 errors
vp test run     # vitest — 64 passed
vp run build    # build OK (incl. /jazz-poc)
vp run knip     # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
