### PR TITLE
Fix over-range +10 logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,4 +40,6 @@ This project started as a learning project by a beginner developer. Expect rough
 
 ## Local Preview
 
+- For a plain local dev server, use `vp run dev`. Astro 7 may run the dev server in the background for agents; use `vp run astro dev status`, `vp run astro dev logs`, and `vp run astro dev stop` to inspect or stop it.
 - See [docs/local-preview.md](docs/local-preview.md) for running a phone-ready preview with Portless and Tailscale, including the Vite `allowedHosts` gotcha.
+- See [docs/e2e-testing.md](docs/e2e-testing.md) for project-specific `agent-browser` smoke testing notes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,6 @@ This project started as a learning project by a beginner developer. Expect rough
 
 ## Local Preview
 
-- For a plain local dev server, use `vp run dev`. Astro 7 may run the dev server in the background for agents; use `vp run astro dev status`, `vp run astro dev logs`, and `vp run astro dev stop` to inspect or stop it.
+- For a plain local dev server, use `vp run dev --background`. This starts the dev server in the background and reports the port; use `vp run astro dev status`, `vp run astro dev logs`, and `vp run astro dev stop` to inspect or stop it.
 - See [docs/local-preview.md](docs/local-preview.md) for running a phone-ready preview with Portless and Tailscale, including the Vite `allowedHosts` gotcha.
 - See [docs/e2e-testing.md](docs/e2e-testing.md) for project-specific `agent-browser` smoke testing notes.

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -13,11 +13,11 @@ agent-browser close --all || true
 Start or verify the Astro dev server:
 
 ```sh
-vp run dev
+vp run dev --background
 vp run astro dev status
 ```
 
-Astro 7 may keep the dev server running in the background. Stop it with:
+Astro 7 keeps this dev server running in the background. Stop it with:
 
 ```sh
 vp run astro dev stop

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -1,0 +1,107 @@
+# E2E Testing
+
+Use `agent-browser` for lightweight browser checks of the local app.
+
+## Start Fresh
+
+Before testing, close old browser pages so saved tabs or stale refs do not affect the run:
+
+```sh
+agent-browser close --all || true
+```
+
+Start or verify the Astro dev server:
+
+```sh
+vp run dev
+vp run astro dev status
+```
+
+Astro 7 may keep the dev server running in the background. Stop it with:
+
+```sh
+vp run astro dev stop
+```
+
+## Open The App
+
+Open the React app route, not just the landing page:
+
+```sh
+agent-browser open --enable react-devtools http://localhost:4321/app/
+agent-browser wait --load networkidle
+agent-browser snapshot -i
+```
+
+Expected basics:
+
+- Page title is `Bored Calendar`.
+- Heading `Your bored moments` is present.
+- Calendar day buttons render.
+- The minutes slider, `+10`, `Clear`, note textbox, and save/update button render.
+
+## Smoke Test Flow
+
+Use this flow to verify the React app is hydrated and IndexedDB persistence works:
+
+```sh
+agent-browser fill @NOTE_REF "Agent browser smoke test"
+agent-browser click @SAVE_REF
+agent-browser wait 500
+agent-browser open http://localhost:4321/app/
+agent-browser wait --load networkidle
+agent-browser snapshot -i
+```
+
+Confirm the note is still present and the save button changed to `Update day`.
+
+The slider can be checked with keyboard input:
+
+```sh
+agent-browser focus @SLIDER_REF
+agent-browser press ArrowRight
+agent-browser snapshot -i
+```
+
+## Off-Screen Button Gotcha
+
+`agent-browser click` can be misleading when controls are low in the viewport. In this app, `+10` and `Clear` may appear clickable in the snapshot but not update state unless they are explicitly scrolled into view first.
+
+Before calling those controls broken, test them like this:
+
+```sh
+agent-browser scrollintoview @PLUS_TEN_REF
+agent-browser click @PLUS_TEN_REF
+agent-browser wait 300
+agent-browser snapshot -i
+
+agent-browser scrollintoview @CLEAR_REF
+agent-browser click @CLEAR_REF
+agent-browser wait 300
+agent-browser snapshot -i
+```
+
+If the control works after `scrollintoview`, treat the first failure as an automation artifact, not an app bug.
+
+## Cleanup Test Data
+
+If a smoke test saves data, remove only the test row from IndexedDB:
+
+```sh
+agent-browser eval "(async () => await new Promise((resolve, reject) => { const req = indexedDB.open('Calendar'); req.onerror = () => reject(req.error); req.onsuccess = () => { const db = req.result; const tx = db.transaction('Logs', 'readwrite'); const store = tx.objectStore('Logs'); const all = store.getAll(); all.onsuccess = () => { for (const row of all.result) if (row.reflection === 'Agent browser smoke test') store.delete(row.id); }; tx.oncomplete = () => resolve('cleaned'); tx.onerror = () => reject(tx.error); }; }))()"
+```
+
+Reload `/app/` and confirm the test note is gone.
+
+## Useful Commands
+
+```sh
+agent-browser snapshot -i
+agent-browser scrollintoview @REF
+agent-browser click @REF
+agent-browser fill @REF "text"
+agent-browser react tree
+agent-browser eval "document.body.innerText"
+```
+
+Refs become stale after page changes. Re-run `agent-browser snapshot -i` after clicks, reloads, or dynamic UI updates.

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -174,8 +174,13 @@ const App: React.FC<{}> = () => {
               trackSize={16}
               trackColor="#F9FAFB"
               dataIndex={Math.min(minutes, maxDialMinutes)}
-              onChange={(value) => {
-                setMinutes(value);
+              onChange={(nextMinutes) => {
+                setMinutes((currentMinutes) => {
+                  if (currentMinutes > maxDialMinutes && nextMinutes === maxDialMinutes) {
+                    return currentMinutes;
+                  }
+                  return nextMinutes;
+                });
               }}
             />
             <div


### PR DESCRIPTION
## Summary

- Keep `+10` additions based on the true selected minutes after the dial visually clamps at 20.
- Add project-specific `agent-browser` e2e smoke testing notes.
- Link the e2e notes from `AGENTS.md` alongside local preview instructions.

## Verification

- [x] `agent-browser` e2e: `5 -> 15 -> 25 -> 35`
- [x] `agent-browser` e2e: seeded `13 -> 23 -> 33`
- [x] `vp check`
- [x] `vp run test`
- [x] `vp run build`
- [x] `vp run knip`